### PR TITLE
Zeroize memory in munmap

### DIFF
--- a/src/libos/src/lib.rs
+++ b/src/libos/src/lib.rs
@@ -16,6 +16,7 @@
 #![feature(option_expect_none)]
 // for UntrustedSliceAlloc in slice_alloc
 #![feature(slice_ptr_get)]
+#![feature(slice_fill)]
 
 #[macro_use]
 extern crate alloc;

--- a/src/libos/src/vm/vm_manager.rs
+++ b/src/libos/src/vm/vm_manager.rs
@@ -24,26 +24,18 @@ impl VMInitializer {
                 // Do nothing
             }
             VMInitializer::FillZeros() => {
-                for b in buf {
-                    *b = 0;
-                }
+                // Filling zero is done in munmap
             }
             VMInitializer::CopyFrom { range } => {
                 let src_slice = unsafe { range.as_slice() };
                 let copy_len = min(buf.len(), src_slice.len());
                 buf[..copy_len].copy_from_slice(&src_slice[..copy_len]);
-                for b in &mut buf[copy_len..] {
-                    *b = 0;
-                }
             }
             VMInitializer::LoadFromFile { file, offset } => {
                 // TODO: make sure that read_at does not move file cursor
                 let len = file
                     .read_at(*offset, buf)
                     .cause_err(|_| errno!(EIO, "failed to init memory from file"))?;
-                for b in &mut buf[len..] {
-                    *b = 0;
-                }
             }
         }
         Ok(())
@@ -357,6 +349,9 @@ impl VMManager {
 
                 // Reset memory permissions
                 Self::apply_perms(&intersection_vma, VMPerms::default());
+                unsafe {
+                    intersection_vma.as_slice_mut().fill(0);
+                }
 
                 vma.subtract(&intersection_vma)
             })
@@ -823,12 +818,18 @@ impl VMManager {
 
 impl Drop for VMManager {
     fn drop(&mut self) {
-        // Ensure that memory permissions are recovered
+        // Ensure that all allocated memories are restored to the default permissions and zeroed
         for vma in &self.vmas {
-            if vma.size() == 0 || vma.perms() == VMPerms::default() {
-                continue;
+            if vma.size() != 0 {
+                warn!("There are unmapped memories");
+
+                if vma.perms() != VMPerms::default() {
+                    Self::apply_perms(vma, VMPerms::default());
+                }
+                unsafe {
+                    vma.as_slice_mut().fill(0);
+                }
             }
-            Self::apply_perms(vma, VMPerms::default());
         }
     }
 }


### PR DESCRIPTION
1. Move the memory zeroization of mmap to munmap to increase mmap
performance
2. Do memory zeroizaiton during the drop of VMManager to guarentee all
allocated memory is zeroized before the next allocation