### PR TITLE
[async-rt] Remove sched_callback.

### DIFF
--- a/src/libos/crates/async-rt/src/config.rs
+++ b/src/libos/crates/async-rt/src/config.rs
@@ -8,15 +8,6 @@ pub fn set_parallelism(parallelism: u32) {
     CONFIG.set_parallelism(parallelism);
 }
 
-/// Set a callback function that will be invoked right before a task will be
-/// scheduled to run.
-///
-/// Similar to `set_parallelism`, this function must be called before using
-/// the executor to take effect. This callback can help integrate into the
-/// async runtime a reactor that processes I/O completions and wakes up tasks.
-pub fn set_sched_callback(f: impl Fn() + Send + Sync + 'static) {
-    CONFIG.set_sched_callback(f);
-}
 
 pub(crate) struct Config {
     inner: Mutex<Inner>,
@@ -24,14 +15,12 @@ pub(crate) struct Config {
 
 struct Inner {
     parallelism: u32,
-    sched_callback: Option<Box<dyn Fn() + Send + Sync + 'static>>,
 }
 
 impl Config {
     pub fn new() -> Self {
         let inner = Inner {
             parallelism: 1,
-            sched_callback: None,
         };
         Self {
             inner: Mutex::new(inner),
@@ -44,23 +33,11 @@ impl Config {
         inner.parallelism = parallelism;
     }
 
-    pub fn set_sched_callback(&self, f: impl Fn() + Send + Sync + 'static) {
-        let boxed_f = Box::new(f) as Box<dyn Fn() + Send + Sync + 'static>;
-        let mut inner = self.inner.lock();
-        inner.sched_callback = Some(boxed_f);
-    }
-
     pub fn parallelism(&self) -> u32 {
         let inner = self.inner.lock();
         inner.parallelism
     }
 
-    pub fn take_sched_callback(&self) -> Box<dyn Fn() + Send + Sync + 'static> {
-        let mut inner = self.inner.lock();
-        inner.sched_callback.take().unwrap_or_else(|| {
-            Box::new(|| { /* dummy callback */ }) as Box<dyn Fn() + Send + Sync + 'static>
-        })
-    }
 }
 
 lazy_static! {

--- a/src/libos/src/entry/enclave.rs
+++ b/src/libos/src/entry/enclave.rs
@@ -83,9 +83,14 @@ pub extern "C" fn occlum_ecall_init(
 
         info!("num_vcpus = {:?}", num_vcpus);
         async_rt::config::set_parallelism(num_vcpus);
-        async_rt::config::set_sched_callback(|| {
+        async_rt::task::spawn(async {
             let io_uring = &crate::io_uring::SINGLETON;
-            io_uring.poll_completions();
+            loop {
+                for _ in 0..100 {
+                    io_uring.poll_completions();
+                }
+                async_rt::sched::yield_().await;
+            }
         });
 
         HAS_INIT.store(true, Ordering::SeqCst);


### PR DESCRIPTION
#26 [async-rt] Should remove set_sched_callback? 

- remove sched_callback in async-rt config and executor.
- add background task (io_uring poll function) when init async-rt.
    - need shutdown these tasks before shutdown executor (not implemented yet).
    - consider add attribute / status to `task` struct later.
- use yield() in background task to avoid running too long. 
    - (one insight: without yield, io_uring poll function will always running.)


needs to do:

- distinguish background tasks and user tasks.    (add attributes for `task` struct ?)
- select suitable thread for background tasks.
- add status for task 
      - avoid waking up repeatedly. 
      - do not wake up tasks with shutdown-status. 
- shutdown background tasks in executor.shutdown().