### PR TITLE
Add cancel and timeout for io-uring-callback.

### DIFF
--- a/src/libos/Cargo.lock
+++ b/src/libos/Cargo.lock
@@ -475,9 +475,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "sgx_libc",
- "sgx_trts",
  "sgx_tstd",
- "sgx_types",
  "slab",
 ]
 

--- a/src/libos/crates/io-uring-callback/Cargo.toml
+++ b/src/libos/crates/io-uring-callback/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [features]
 default = ["libc"]
-sgx = ["sgx_types", "sgx_tstd", "sgx_trts", "sgx_libc", "io-uring/sgx"]
+sgx = ["sgx_tstd", "sgx_libc", "io-uring/sgx"]
 
 [dependencies]
 atomic = "0.5.0"
@@ -19,9 +19,7 @@ slab = { git = "https://github.com/tokio-rs/slab.git", default-features = false 
 libc = { version = "0.2.0", optional = true }
 
 io-uring = { path = "../../../../deps/io-uring", features = ["concurrent"]  }
-sgx_types = { path = "../../../../deps/rust-sgx-sdk/sgx_types", optional = true }
 sgx_tstd = { path = "../../../../deps/rust-sgx-sdk/sgx_tstd", optional = true, features = ["backtrace"] }
-sgx_trts = { path = "../../../../deps/rust-sgx-sdk/sgx_trts", optional = true }
 sgx_libc = { path = "../../../../deps/rust-sgx-sdk/sgx_libc", optional = true }
 
 [dev-dependencies]

--- a/src/libos/crates/io-uring-callback/examples/sgx/enclave/src/lib.rs
+++ b/src/libos/crates/io-uring-callback/examples/sgx/enclave/src/lib.rs
@@ -187,7 +187,7 @@ pub extern "C" fn run_sgx_example() -> sgx_status_t {
                     };
 
                     let handle =
-                        unsafe { ring.poll_add(types::Fd(fd), libc::POLLIN as _, complete_fn) };
+                        unsafe { ring.poll(types::Fd(fd), libc::POLLIN as _, complete_fn) };
 
                     slab_entry.insert(handle);
                 }

--- a/src/libos/crates/io-uring-callback/examples/tcp_echo.rs
+++ b/src/libos/crates/io-uring-callback/examples/tcp_echo.rs
@@ -111,7 +111,7 @@ fn main() {
                     };
 
                     let handle =
-                        unsafe { ring.poll_add(types::Fd(fd), libc::POLLIN as _, complete_fn) };
+                        unsafe { ring.poll(types::Fd(fd), libc::POLLIN as _, complete_fn) };
 
                     slab_entry.insert(handle);
                 }
@@ -212,7 +212,7 @@ fn main() {
                         };
 
                         let handle =
-                            unsafe { ring.poll_add(types::Fd(fd), libc::POLLIN as _, complete_fn) };
+                            unsafe { ring.poll(types::Fd(fd), libc::POLLIN as _, complete_fn) };
 
                         slab_entry.insert(handle);
                     } else {

--- a/src/libos/crates/io-uring-callback/src/io_handle.rs
+++ b/src/libos/crates/io-uring-callback/src/io_handle.rs
@@ -13,20 +13,23 @@ cfg_if::cfg_if! {
 
 /// The handle to an I/O request pushed to the submission queue of an io_uring instance.
 #[derive(Debug)]
-pub struct IoHandle(Arc<IoToken>);
+pub struct IoHandle(pub(crate) Arc<IoToken>);
 
 /// The state of an I/O request represented by an [`IoHandle`].
+/// If a request is in `Processed` or `Cancelled` state, means that the request is completed.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum IoState {
-    /// Submitted.
+    /// The I/O request has been submitted.
     Submitted,
-    /// Completed with a return value.
-    Completed(i32),
-    /// Cancelling (not used yet).
+    /// The I/O request has been processed by the kernel and returns a value.
+    Processed(i32),
+    /// The I/O request is being cancelled.
     Cancelling,
-    /// Cancelled (not used yet).
+    /// The I/O request has been cancelled by the kernel.
     Cancelled,
 }
+
+const CANCEL_RETVAL: i32 = -libc::ECANCELED;
 
 impl IoHandle {
     pub(crate) fn new(token: Arc<IoToken>) -> Self {
@@ -42,13 +45,6 @@ impl IoHandle {
     pub fn retval(&self) -> Option<i32> {
         self.0.retval()
     }
-
-    /// Cancel the I/O request.
-    ///
-    /// This is NOT implemented, yet.
-    pub fn cancel(&self) {
-        self.0.cancel()
-    }
 }
 
 impl Unpin for IoHandle {}
@@ -59,13 +55,11 @@ impl Future for IoHandle {
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let mut inner = self.0.inner.lock().unwrap();
         match inner.state {
-            IoState::Completed(retval) => Poll::Ready(retval),
-            IoState::Submitted => {
+            IoState::Processed(retval) => Poll::Ready(retval),
+            IoState::Cancelled => Poll::Ready(CANCEL_RETVAL),
+            IoState::Submitted | IoState::Cancelling => {
                 inner.waker = Some(cx.waker().clone());
                 Poll::Pending
-            }
-            _ => {
-                todo!("handle cancel-related states");
             }
         }
     }
@@ -73,8 +67,8 @@ impl Future for IoHandle {
 
 impl Drop for IoHandle {
     fn drop(&mut self) {
-        // The user cannot drop a handle without completing or canceling it first.
-        assert!(matches!(self.state(), IoState::Completed(_) | IoState::Cancelled));
+        // The user cannot drop a handle if the request isn't completed.
+        assert!(matches!(self.state(), IoState::Processed(_) | IoState::Cancelled));
     }
 }
 
@@ -87,8 +81,8 @@ pub(crate) struct IoToken {
 }
 
 impl IoToken {
-    pub fn new(callback: impl FnOnce(i32) + Send + 'static) -> Self {
-        let inner = Mutex::new(Inner::new(callback));
+    pub fn new(completion_callback: impl FnOnce(i32) + Send + 'static, token_key: u64) -> Self {
+        let inner = Mutex::new(Inner::new(completion_callback, token_key));
         Self { inner }
     }
 
@@ -113,9 +107,11 @@ impl IoToken {
         (callback)(retval);
     }
 
-    pub fn cancel(&self) {
+    /// Change the state from submited to cancelling.
+    /// If transition succeeds, return the token_key for following cancel operation.
+    pub fn transit_to_cancelling(&self) -> Result<u64, ()> {
         let mut inner = self.inner.lock().unwrap();
-        inner.cancel()
+        inner.transit_to_cancelling()
     }
 }
 
@@ -129,44 +125,65 @@ impl std::fmt::Debug for IoToken {
 
 struct Inner {
     state: IoState,
-    callback: Option<Callback>,
+    completion_callback: Option<Callback>,
     waker: Option<Waker>,
+    token_key: u64,
 }
 
 type Callback = Box<dyn FnOnce(i32) + Send + 'static>;
 
 impl Inner {
-    pub fn new(callback: impl FnOnce(i32) + Send + 'static) -> Self {
+    pub fn new(completion_callback: impl FnOnce(i32) + Send + 'static, token_key: u64) -> Self {
         let state = IoState::Submitted;
-        let callback = Some(Box::new(callback) as _);
+        let completion_callback = Some(Box::new(completion_callback) as _);
         let waker = None;
         Self {
             state,
-            callback,
+            completion_callback,
             waker,
+            token_key,
         }
     }
 
     pub fn complete(&mut self, retval: i32) -> Callback {
         match self.state {
-            IoState::Submitted | IoState::Cancelling => {
-                self.state = IoState::Completed(retval);
+            IoState::Submitted => {
+                self.state = IoState::Processed(retval);
+            }
+            IoState::Cancelling => {
+                if retval == CANCEL_RETVAL {
+                    // case 1: The request was cancelled successfully.
+                    self.state = IoState::Cancelled;
+                } else {
+                    // case 2.1: The request was cancelled with error.
+                    // case 2.2: The request was not actually canceled.
+                    self.state = IoState::Processed(retval);
+                }
             }
             _ => {
-                unreachable!("cannot do complete twice or after cancelled");
+                unreachable!("cannot do complete twice");
             }
         }
 
-        self.callback.take().unwrap()
+        self.completion_callback.take().unwrap()
     }
 
-    pub fn cancel(&mut self) {
-        todo!("implement cancel in future")
+    pub fn transit_to_cancelling(&mut self) -> Result<u64, ()> {
+        match self.state {
+            IoState::Submitted => {
+                self.state = IoState::Cancelling;
+                return Ok(self.token_key);
+            }
+            _ => {
+                return Err(());
+            }
+        }
     }
 
     pub fn retval(&self) -> Option<i32> {
         match self.state {
-            IoState::Completed(retval) => Some(retval),
+            IoState::Processed(retval) => Some(retval),
+            IoState::Cancelled => Some(CANCEL_RETVAL),
             _ => None,
         }
     }


### PR DESCRIPTION
#### add cancel / timeout / timeout_remove for io-uring-callback.
#### add do_timeout for libos.


- To implement cancel, we pass a IoUring reference parameter for cancel().   (It's complicated to store IoUring ref in the IoToken, which causes circular-reference, lifetime problem ...)
- Add do_timeout for libos using io-uring timeout.
- Only use do_timeout() in do_sigtimedwait() for now. Since io-uring timeout cannot support signal wake-up and remaining time (nanosleep)


##### How to support nanosleep?
- require:  wake up by signal
- require:  calculate remaining time if waked up by signal.