### PR TITLE
Timeout support.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -29,3 +29,7 @@
 [submodule "deps/io-uring"]
 	path = deps/io-uring
 	url = https://github.com/occlum/io-uring
+[submodule "deps/rust-hash-wheel-timer"]
+	path = deps/rust-hash-wheel-timer
+	url = https://github.com/ShuochengWang/rust-hash-wheel-timer.git
+	branch = sgx

--- a/src/Enclave.edl
+++ b/src/Enclave.edl
@@ -116,11 +116,6 @@ enclave {
         void occlum_ocall_rdtsc([out] uint32_t* low, [out] uint32_t* high);
         void occlum_ocall_get_timerslack([out] int *timer_slack);
 
-        int occlum_ocall_nanosleep(
-            [in] const struct timespec* req,
-            [out] struct timespec* rem
-        ) propagate_errno;
-
         void occlum_ocall_sync(void);
 
         void* occlum_ocall_posix_memalign(size_t alignment, size_t size);

--- a/src/Enclave.edl
+++ b/src/Enclave.edl
@@ -113,9 +113,6 @@ enclave {
 
         int occlum_ocall_thread_getcpuclock([out] struct timespec* ts) propagate_errno;
 
-        void occlum_ocall_gettimeofday([out] struct timeval* tv);
-        void occlum_ocall_clock_gettime(clockid_t clockid, [out] struct timespec* ts);
-        void occlum_ocall_clock_getres(clockid_t clockid, [out] struct timespec* res);
         void occlum_ocall_rdtsc([out] uint32_t* low, [out] uint32_t* high);
         void occlum_ocall_get_timerslack([out] int *timer_slack);
 

--- a/src/libos/Cargo.lock
+++ b/src/libos/Cargo.lock
@@ -89,14 +89,17 @@ version = "0.1.0"
 dependencies = [
  "atomic",
  "bit-vec",
+ "errno",
  "flume",
  "futures",
+ "hierarchical_hash_wheel_timer",
  "intrusive-collections",
  "lazy_static",
  "log",
  "object-id",
  "sgx_tstd",
  "spin 0.7.0",
+ "vdso-time",
 ]
 
 [[package]]
@@ -353,6 +356,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "611834ce18aaa1bd13c4b374f5d653e1027cf99b6b502584ff8c9a64413b30bb"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77408a692f1f97bcc61dc001d752e00643408fbc922e4d634c655df50d595556"
+dependencies = [
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -371,10 +386,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d304cff4a7b99cfb7986f7d43fbe93d175e72e704a8860787cc95e9ffd85cbd2"
 dependencies = [
  "futures-core",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "pin-project",
  "pin-utils",
+ "proc-macro-hack",
+ "proc-macro-nested",
 ]
 
 [[package]]
@@ -398,6 +416,13 @@ dependencies = [
 [[package]]
 name = "hashbrown_tstd"
 version = "0.9.0"
+
+[[package]]
+name = "hierarchical_hash_wheel_timer"
+version = "1.1.0"
+dependencies = [
+ "sgx_tstd",
+]
 
 [[package]]
 name = "host-socket"
@@ -625,6 +650,18 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "proc-macro-hack"
+version = "0.5.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
+
+[[package]]
+name = "proc-macro-nested"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
@@ -1087,7 +1124,13 @@ dependencies = [
 name = "vdso-time"
 version = "0.1.0"
 dependencies = [
+ "cfg-if 1.0.0",
+ "errno",
+ "lazy_static",
+ "libc",
+ "log",
  "sgx_libc",
+ "sgx_trts",
  "sgx_tstd",
  "sgx_types",
 ]

--- a/src/libos/Cargo.toml
+++ b/src/libos/Cargo.toml
@@ -8,7 +8,7 @@ name = "occlum_libos_core_rs"
 crate-type = ["staticlib"]
 
 [dependencies]
-async-rt  = { path = "crates/async-rt", features = ["sgx", "thread_sleep"] }
+async-rt  = { path = "crates/async-rt", default-features = false, features = ["sgx"] }
 async-io  = { path = "crates/async-io", features = ["sgx"] }
 atomic = "0.5"
 bitflags = "1.0"

--- a/src/libos/crates/async-io/src/event/event_counter.rs
+++ b/src/libos/crates/async-io/src/event/event_counter.rs
@@ -24,7 +24,8 @@ impl EventCounter {
             if val > 0 {
                 return val;
             }
-        });
+        })
+        .unwrap()
     }
 
     pub fn write(&self) {

--- a/src/libos/crates/async-rt/Cargo.toml
+++ b/src/libos/crates/async-rt/Cargo.toml
@@ -7,9 +7,9 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = []
+default = ["vdso-time/std"]
 auto_run = []
-sgx = ["flume/sgx", "sgx_tstd"]
+sgx = ["sgx_tstd", "flume/sgx", "vdso-time/sgx", "hierarchical_hash_wheel_timer/sgx"]
 
 [dependencies]
 atomic = "0.5"
@@ -17,12 +17,14 @@ bit-vec = { version = "0.6", default-features = false }
 errno = { path = "../errno" }
 flume = { path = "../../../../deps/flume", default-features = false }
 futures = { version = "0.3", default-features = false, features = ["alloc", "async-await"] }
+hierarchical_hash_wheel_timer = { path = "../../../../deps/rust-hash-wheel-timer", default-features = false, features = ["sip-hash"]}
 intrusive-collections = "0.9"
 lazy_static = { version = "1.4.0", features = ["spin_no_std"] }
 log = "0.4"
 object-id = { path = "../object-id" }
 spin = "0.7"
 sgx_tstd = { path = "../../../../deps/rust-sgx-sdk/sgx_tstd", features = ["backtrace", "thread"], optional = true }
+vdso-time = { path = "../vdso-time", default-features = false }
 
 [dev-dependencies]
 ctor = "0.1"

--- a/src/libos/crates/async-rt/Cargo.toml
+++ b/src/libos/crates/async-rt/Cargo.toml
@@ -9,17 +9,17 @@ edition = "2018"
 [features]
 default = []
 auto_run = []
-thread_sleep = [] # need std or sgx_tstd
 sgx = ["flume/sgx", "sgx_tstd"]
 
 [dependencies]
 atomic = "0.5"
-bit-vec = { version = "0.6", default-features = false  }
+bit-vec = { version = "0.6", default-features = false }
+errno = { path = "../errno" }
 flume = { path = "../../../../deps/flume", default-features = false }
-futures = { version = "0.3", default-features = false, features = ["alloc"]  }
-log = { version = "0.4" }
+futures = { version = "0.3", default-features = false, features = ["alloc", "async-await"] }
 intrusive-collections = "0.9"
 lazy_static = { version = "1.4.0", features = ["spin_no_std"] }
+log = "0.4"
 object-id = { path = "../object-id" }
 spin = "0.7"
 sgx_tstd = { path = "../../../../deps/rust-sgx-sdk/sgx_tstd", features = ["backtrace", "thread"], optional = true }

--- a/src/libos/crates/async-rt/README.md
+++ b/src/libos/crates/async-rt/README.md
@@ -11,5 +11,5 @@ async-rt = { path = "your_path/async-rt" }
 
 if use async-rt in SGX (based on rust-sgx-sdk), place the following line under the `[dependencies]` section in your `Cargo.toml` and prepare incubator-teaclave-sgx-sdk envirenments according to async-rt's `Cargo.toml`:
 ```
-async-rt = { path = "your_path/async-rt", features = ["sgx"]  }
+async-rt = { path = "your_path/async-rt", default-features = false, features = ["sgx"]  }
 ```

--- a/src/libos/crates/async-rt/src/lib.rs
+++ b/src/libos/crates/async-rt/src/lib.rs
@@ -1,10 +1,4 @@
-#![cfg_attr(
-    any(
-        not(any(test, feature = "auto_run", feature = "thread_sleep")),
-        feature = "sgx"
-    ),
-    no_std
-)]
+#![cfg_attr(feature = "sgx", no_std)]
 #![feature(const_fn)]
 #![feature(thread_local)]
 #![feature(const_fn_fn_ptr_basics)]
@@ -13,18 +7,10 @@
 #[macro_use]
 extern crate sgx_tstd as std;
 extern crate alloc;
-extern crate bit_vec;
-#[macro_use]
-extern crate lazy_static;
-//#[macro_use]
-//extern crate log;
-extern crate flume;
-extern crate spin;
 
 pub mod config;
 pub mod executor;
 mod macros;
-#[cfg(feature = "thread_sleep")]
 mod parks;
 pub mod prelude;
 pub mod sched;
@@ -121,13 +107,13 @@ mod tests {
     }
 
     mod logger {
-        use log::{Level, LevelFilter, Metadata, Record, SetLoggerError};
+        use log::{Level, LevelFilter, Metadata, Record};
 
         #[ctor::ctor]
         fn auto_init() {
             log::set_logger(&LOGGER)
-                .map(|()| log::set_max_level(LevelFilter::Info))
-                .expect("failed to init the");
+                .map(|()| log::set_max_level(LevelFilter::Trace))
+                .expect("failed to init the logger");
         }
 
         static LOGGER: SimpleLogger = SimpleLogger;
@@ -136,7 +122,7 @@ mod tests {
 
         impl log::Log for SimpleLogger {
             fn enabled(&self, metadata: &Metadata) -> bool {
-                metadata.level() <= Level::Info
+                metadata.level() <= Level::Trace
             }
 
             fn log(&self, record: &Record) {

--- a/src/libos/crates/async-rt/src/lib.rs
+++ b/src/libos/crates/async-rt/src/lib.rs
@@ -2,6 +2,9 @@
 #![feature(const_fn)]
 #![feature(thread_local)]
 #![feature(const_fn_fn_ptr_basics)]
+#![feature(duration_zero)]
+#![feature(duration_constants)]
+#![feature(duration_saturating_ops)]
 
 #[cfg(feature = "sgx")]
 #[macro_use]
@@ -15,6 +18,7 @@ mod parks;
 pub mod prelude;
 pub mod sched;
 pub mod task;
+pub mod time;
 pub mod wait;
 
 // All unit tests

--- a/src/libos/crates/async-rt/src/parks/mod.rs
+++ b/src/libos/crates/async-rt/src/parks/mod.rs
@@ -1,10 +1,8 @@
-use spin::Mutex;
-use std::sync::Arc;
+use crate::prelude::*;
 #[cfg(feature = "sgx")]
 use std::thread::SgxThread as Thread;
 #[cfg(not(feature = "sgx"))]
 use std::thread::Thread;
-use std::vec::Vec;
 
 pub struct Parks {
     sleep_threads: Vec<Mutex<Option<Thread>>>,

--- a/src/libos/crates/async-rt/src/prelude.rs
+++ b/src/libos/crates/async-rt/src/prelude.rs
@@ -9,6 +9,7 @@ pub(crate) use spin::mutex::Mutex;
 
 pub use core::future::Future;
 pub use core::pin::Pin;
+pub use core::time::Duration;
 pub use futures::future::{BoxFuture, FutureExt};
 
 pub use crate::task_local;

--- a/src/libos/crates/async-rt/src/prelude.rs
+++ b/src/libos/crates/async-rt/src/prelude.rs
@@ -3,6 +3,8 @@ pub(crate) use alloc::sync::Arc;
 pub(crate) use alloc::vec::Vec;
 pub(crate) use core::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
 pub(crate) use core::task::{Context, Poll};
+pub(crate) use errno::prelude::*;
+pub(crate) use lazy_static::lazy_static;
 pub(crate) use spin::mutex::Mutex;
 
 pub use core::future::Future;
@@ -10,5 +12,3 @@ pub use core::pin::Pin;
 pub use futures::future::{BoxFuture, FutureExt};
 
 pub use crate::task_local;
-
-pub type Result<T> = core::result::Result<T, &'static str>;

--- a/src/libos/crates/async-rt/src/sched/yield_.rs
+++ b/src/libos/crates/async-rt/src/sched/yield_.rs
@@ -1,5 +1,3 @@
-use core::task::{Context, Poll};
-
 use crate::prelude::*;
 
 pub fn yield_() -> Yield {

--- a/src/libos/crates/async-rt/src/task/join.rs
+++ b/src/libos/crates/async-rt/src/task/join.rs
@@ -1,6 +1,6 @@
 use alloc::sync::Weak;
 use core::marker::PhantomData;
-use core::task::{Context, Poll, Waker};
+use core::task::Waker;
 
 use crate::prelude::*;
 

--- a/src/libos/crates/async-rt/src/task/mod.rs
+++ b/src/libos/crates/async-rt/src/task/mod.rs
@@ -1,6 +1,3 @@
-use alloc::sync::Arc;
-use core::future::Future;
-
 use crate::executor::EXECUTOR;
 use crate::prelude::*;
 

--- a/src/libos/crates/async-rt/src/task/task.rs
+++ b/src/libos/crates/async-rt/src/task/task.rs
@@ -1,6 +1,5 @@
 use core::fmt::{self, Debug};
 
-use futures::future::{BoxFuture, FutureExt};
 use futures::task::ArcWake;
 
 use crate::executor::EXECUTOR;

--- a/src/libos/crates/async-rt/src/time/entry.rs
+++ b/src/libos/crates/async-rt/src/time/entry.rs
@@ -1,0 +1,189 @@
+use super::wheel::TIMER_WHEEL;
+use super::DURATION_ZERO;
+use crate::prelude::*;
+use core::task::Waker;
+
+/// The state of timer.
+#[derive(Debug)]
+pub enum TimerState {
+    /// This timer has not been inserted to the timer wheel.
+    Init,
+    /// This timer has been inserted to the timer wheel and waits timeout.
+    Started(StartedInner),
+    /// This timer has expired, which means the wheel has triggered the timer.
+    Expired,
+    /// This timer has been cancelled, and records elapsed time between started and cancelled state.
+    Cancelled(Duration),
+}
+
+#[derive(Debug)]
+pub struct StartedInner {
+    start_ticks: u64,
+    waker: Option<Waker>,
+}
+
+impl StartedInner {
+    pub fn new(start_ticks: u64, waker: Waker) -> Self {
+        Self {
+            start_ticks,
+            waker: Some(waker),
+        }
+    }
+
+    pub fn wake(&mut self) {
+        self.waker.take().unwrap().wake();
+    }
+
+    pub fn set_waker(&mut self, waker: Waker) {
+        self.waker = Some(waker);
+    }
+
+    pub fn elapsed_time(&self) -> Duration {
+        let elapsed_ticks = TIMER_WHEEL.latest_ticks() - self.start_ticks;
+        Duration::from_millis(elapsed_ticks)
+    }
+}
+
+/// The shared data structure of timer.
+#[derive(Debug)]
+pub struct TimerShared {
+    state: TimerState,
+    timeout: Duration,
+}
+
+/// The wrapper of `TimerShared` with `Send` and `Sync`.
+pub type TimerSharedRef = Arc<Mutex<TimerShared>>;
+
+impl TimerShared {
+    pub fn new(timeout: Duration) -> Self {
+        Self {
+            state: TimerState::Init,
+            timeout: timeout,
+        }
+    }
+
+    /// Transfer to expired state and wake up the timer.
+    pub fn fire(&mut self) {
+        match &mut self.state {
+            // This timer has been cancelled, do nothing here.
+            TimerState::Cancelled(_) => {}
+            // Transfer to expired state and wake up the timer.
+            TimerState::Started(inner) => {
+                // Since TimerShared is guarded by the lock, we can wake before setting expired state
+                inner.wake();
+                self.state = TimerState::Expired;
+            }
+            _ => panic!("Can not fire timer in init or expired state"),
+        }
+    }
+
+    /// Transfer to cancelled state
+    pub fn cancel(&mut self) {
+        match &self.state {
+            TimerState::Init => {
+                self.state = TimerState::Cancelled(DURATION_ZERO);
+            }
+            TimerState::Started(inner) => {
+                self.state = TimerState::Cancelled(inner.elapsed_time());
+            }
+            TimerState::Expired => {}
+            TimerState::Cancelled(_) => panic!("Can not cancel twice"),
+        }
+    }
+
+    /// Get the remained duration.
+    pub fn remained_duration(&self) -> Duration {
+        match &self.state {
+            TimerState::Init => self.timeout,
+            TimerState::Started(inner) => {
+                // If timeout is less than 1ms, we will wait 1ms instead.
+                // It might cause the timeout is less than elapsed_time.
+                return self.timeout.saturating_sub(inner.elapsed_time());
+            }
+            TimerState::Expired => DURATION_ZERO,
+            TimerState::Cancelled(elapsed) => self.timeout.saturating_sub(*elapsed),
+        }
+    }
+}
+
+/// The entry used by user to get remained duration.
+#[derive(Debug)]
+pub struct TimerEntry(TimerSharedRef);
+
+/// The entry used for `await` or `poll`.
+#[derive(Debug)]
+pub struct TimerFutureEntry(TimerSharedRef);
+
+/// The entry used for timer wheel. This entry will be inserted to the timer wheel.
+/// When the timer wheel trigger this entry, the wheel will invoke `fire()` to fire the timer.
+#[derive(Debug)]
+pub struct TimerWheelEntry(TimerSharedRef);
+
+impl TimerEntry {
+    pub fn new(timeout: Duration) -> Self {
+        Self(Arc::new(Mutex::new(TimerShared::new(timeout))))
+    }
+
+    // Get the remained duration.
+    pub fn remained_duration(&self) -> Duration {
+        let shared = self.0.lock();
+        shared.remained_duration()
+    }
+}
+
+impl TimerFutureEntry {
+    pub fn new(entry: &TimerEntry) -> Self {
+        Self(entry.0.clone())
+    }
+}
+
+impl Future for TimerFutureEntry {
+    type Output = ();
+
+    /// Return Ready if the timer is expired, or Pending.
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let mut shared = self.0.lock();
+        match &mut shared.state {
+            TimerState::Init => {
+                // If the timeout is zero, return directly.
+                if shared.timeout.is_zero() {
+                    shared.state = TimerState::Expired;
+                    return Poll::Ready(());
+                }
+
+                // Insert the timer entry to the timer wheel.
+                let entry = TimerWheelEntry(self.0.clone());
+                let start_ticks = TIMER_WHEEL.insert_entry(entry, shared.timeout);
+                // Transfer to started state, set start_tick and waker.
+                let inner = StartedInner::new(start_ticks, cx.waker().clone());
+                shared.state = TimerState::Started(inner);
+                Poll::Pending
+            }
+            TimerState::Started(inner) => {
+                inner.set_waker(cx.waker().clone());
+                Poll::Pending
+            }
+            TimerState::Expired => Poll::Ready(()),
+            TimerState::Cancelled(_) => panic!("Can not poll cancelled timer entry"),
+        }
+    }
+}
+
+impl Drop for TimerFutureEntry {
+    /// Make sure that the state is Init, Expired or Cancelled after drop.
+    /// If the state is Started, cancel the timer before dropped.
+    fn drop(&mut self) {
+        let mut shared = self.0.lock();
+        if let TimerState::Started(_) = shared.state {
+            shared.cancel();
+        }
+    }
+}
+
+impl TimerWheelEntry {
+    /// Fire the timer.
+    pub fn fire(&self) {
+        let mut shared = self.0.lock();
+        shared.fire();
+    }
+}

--- a/src/libos/crates/async-rt/src/time/instant.rs
+++ b/src/libos/crates/async-rt/src/time/instant.rs
@@ -1,0 +1,125 @@
+use crate::prelude::*;
+use core::ops::{Add, AddAssign, Sub, SubAssign};
+use vdso_time::{clock_gettime, ClockId};
+
+lazy_static! {
+    static ref LAST_NOW: Mutex<Instant> = Mutex::new(Instant(DURATION_ZERO));
+}
+
+pub const DURATION_ZERO: Duration = Duration::from_nanos(0);
+
+/// A measurement of a monotonically nondecreasing clock. Opaque and useful only with Duration.
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+pub struct Instant(pub(crate) Duration);
+
+impl Instant {
+    /// Returns an instant corresponding to “now”.
+    ///
+    /// Rust std says that the clock of linux + x86 environment is real-monotonic.
+    /// When sgx feature enabled, we are in linux + x86 env, the clock should be real-monotonic.
+    /// However, the clock in sgx env is untrusted, we can not guarantee that clock is real-monotonic.
+    /// To ensure the instant is monotonically nondecreasing, We keep a global "latest now" instance
+    /// which is returned instead of what the OS says if the OS goes backwards.
+    pub fn now() -> Self {
+        let os_now = Instant(clock_gettime(ClockId::CLOCK_MONOTONIC).unwrap());
+
+        let mut last_now = LAST_NOW.lock();
+        let now = core::cmp::max(*last_now, os_now);
+        *last_now = now;
+
+        now
+    }
+
+    /// Returns the amount of time elapsed from another instant to this one.
+    pub fn duration_since(&self, earlier: Instant) -> Duration {
+        self.0
+            .checked_sub(earlier.0)
+            .expect("earlier is later than self.")
+    }
+
+    /// Returns the amount of time elapsed from another instant to this one,
+    /// or None if that instant is later than this one.
+    pub fn checked_duration_since(&self, earlier: Instant) -> Option<Duration> {
+        self.0.checked_sub(earlier.0)
+    }
+
+    /// Returns the amount of time elapsed from another instant to this one,
+    /// or zero duration if that instant is later than this one.
+    pub fn saturating_duration_since(&self, earlier: Instant) -> Duration {
+        self.0.checked_sub(earlier.0).unwrap_or(DURATION_ZERO)
+    }
+
+    /// Returns the amount of time elapsed since this instant was created,
+    /// or zero duration if Instant::now() is earlier than this one.
+    pub fn elapsed(&self) -> Duration {
+        Instant::now() - *self
+    }
+
+    /// Returns Some(t) where t is the time self + duration if t can be represented as Instant
+    /// (which means it’s inside the bounds of the underlying data structure), None otherwise.
+    pub fn checked_add(&self, duration: Duration) -> Option<Instant> {
+        Some(Instant(self.0.checked_add(duration)?))
+    }
+
+    /// Returns Some(t) where t is the time self - duration if t can be represented as Instant
+    /// (which means it’s inside the bounds of the underlying data structure), None otherwise.
+    pub fn checked_sub(&self, duration: Duration) -> Option<Instant> {
+        Some(Instant(self.0.checked_sub(duration)?))
+    }
+}
+
+impl Sub<Instant> for Instant {
+    type Output = Duration;
+
+    fn sub(self, other: Instant) -> Duration {
+        self.duration_since(other)
+    }
+}
+
+impl Add<Duration> for Instant {
+    type Output = Instant;
+
+    fn add(self, other: Duration) -> Instant {
+        self.checked_add(other)
+            .expect("overflow when adding duration to instant")
+    }
+}
+
+impl AddAssign<Duration> for Instant {
+    fn add_assign(&mut self, other: Duration) {
+        *self = *self + other;
+    }
+}
+
+impl Sub<Duration> for Instant {
+    type Output = Instant;
+
+    fn sub(self, other: Duration) -> Instant {
+        self.checked_sub(other)
+            .expect("overflow when subtracting duration from instant")
+    }
+}
+
+impl SubAssign<Duration> for Instant {
+    fn sub_assign(&mut self, other: Duration) {
+        *self = *self - other;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Duration, Instant};
+    use std::thread;
+
+    #[test]
+    fn test_instant() {
+        let start = Instant::now();
+
+        let ms = 100;
+        thread::sleep(Duration::from_millis(ms));
+
+        let elapsed = start.elapsed();
+        assert!(elapsed.as_millis() as u64 >= ms - 1);
+        assert!(elapsed.as_millis() as u64 <= ms + 1);
+    }
+}

--- a/src/libos/crates/async-rt/src/time/mod.rs
+++ b/src/libos/crates/async-rt/src/time/mod.rs
@@ -1,0 +1,6 @@
+pub(crate) use self::entry::{TimerEntry, TimerFutureEntry};
+pub use self::instant::{Instant, DURATION_ZERO};
+
+mod entry;
+mod instant;
+mod wheel;

--- a/src/libos/crates/async-rt/src/time/wheel.rs
+++ b/src/libos/crates/async-rt/src/time/wheel.rs
@@ -1,0 +1,103 @@
+use super::entry::TimerWheelEntry;
+use super::Instant;
+use crate::prelude::*;
+use spin::mutex::MutexGuard;
+
+use hierarchical_hash_wheel_timer::wheels::quad_wheel::QuadWheelWithOverflow;
+
+lazy_static! {
+    pub static ref TIMER_WHEEL: TimerWheel = {
+        use crate::executor::EXECUTOR;
+        use crate::sched::yield_;
+        use crate::task::Task;
+
+        let wheel = TimerWheel::new();
+
+        // TODO: Don't always run this task when no useful tasks to run and no timeouts to expire.
+        let task = Arc::new(Task::new(async {
+            loop {
+                TIMER_WHEEL.try_make_progress();
+                yield_().await;
+            }
+        }));
+        EXECUTOR.accept_task(task);
+
+        wheel
+    };
+}
+
+/// The interface of hierarchical timer wheel. The resolution of time is 1ms.
+pub struct TimerWheel {
+    // hierarchical timer wheel.
+    wheel: Mutex<QuadWheelWithOverflow<TimerWheelEntry>>,
+    // current ticks, one tick means 1ms.
+    ticks: AtomicU64,
+    // start time of the timerwheel.
+    start: Instant,
+}
+
+impl TimerWheel {
+    pub fn new() -> Self {
+        Self {
+            wheel: Mutex::new(QuadWheelWithOverflow::default()),
+            ticks: AtomicU64::new(0),
+            start: Instant::now(),
+        }
+    }
+
+    /// Insert a new timer entry to the wheel and return the ticks when the entry is inserted.
+    pub fn insert_entry(&self, entry: TimerWheelEntry, timeout: Duration) -> u64 {
+        let mut guard = self.wheel.lock();
+
+        // Try to make progress to assure that the wheel is up to date.
+        let entries = self.make_progress(&mut guard);
+
+        // The minimum resolution of QuadWheelWithOverflow is 1 ms.
+        // If the timeout less than 1 ms, wait 1ms instead.
+        let timeout = core::cmp::max(timeout, Duration::MILLISECOND);
+        guard.insert_with_delay(entry, timeout).unwrap();
+        let insert_ticks = self.latest_ticks();
+
+        drop(guard);
+        Self::fire(entries);
+
+        insert_ticks
+    }
+
+    /// Try to move the timerwheel forward and fire expired timers.
+    pub fn try_make_progress(&self) {
+        if let Some(mut wheel_guard) = self.wheel.try_lock() {
+            let entries = self.make_progress(&mut wheel_guard);
+            drop(wheel_guard);
+            Self::fire(entries);
+        }
+    }
+
+    /// Try to move the timerwheel forward and return all expired timers.
+    ///
+    /// The returned timers must be fired by `fire()`!
+    fn make_progress(
+        &self,
+        wheel_guard: &mut MutexGuard<QuadWheelWithOverflow<TimerWheelEntry>>,
+    ) -> Vec<TimerWheelEntry> {
+        let elapsed = self.start.elapsed().as_millis() as u64;
+        // calculate the step that we need move forward, in most times, it should be 0 or 1.
+        let diff = elapsed - self.latest_ticks();
+        self.ticks.store(elapsed, Ordering::Release);
+        let mut entries = Vec::new();
+        for _ in 0..diff {
+            entries.append(&mut wheel_guard.tick())
+        }
+        entries
+    }
+
+    /// Fire expired timers.
+    fn fire(entries: Vec<TimerWheelEntry>) {
+        entries.iter().for_each(|e| e.fire());
+    }
+
+    /// Get latest ticks.
+    pub fn latest_ticks(&self) -> u64 {
+        self.ticks.load(Ordering::Relaxed)
+    }
+}

--- a/src/libos/crates/async-rt/src/wait/mod.rs
+++ b/src/libos/crates/async-rt/src/wait/mod.rs
@@ -8,10 +8,9 @@ pub use self::waiter_queue::WaiterQueue;
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
-
     use self::queue::Queue;
     use super::*;
+    use crate::prelude::*;
 
     mod queue {
         use super::*;
@@ -34,30 +33,30 @@ mod tests {
                 }
             }
 
-            pub async fn produce(&self, item: T) {
-                crate::waiter_loop!(&self.producers, {
+            pub async fn produce(&self, item: T, mut timeout: Option<&mut Duration>) -> Result<()> {
+                crate::waiter_loop!(&self.producers, timeout, {
                     let mut buf = self.buf.lock().unwrap();
                     if buf.len() < buf.capacity() {
                         buf.push_back(item);
                         drop(buf);
 
                         self.consumers.wake_one();
-                        return;
+                        return Ok(());
                     }
-                });
+                })
             }
 
-            pub async fn consume(&self) -> T {
-                crate::waiter_loop!(&self.consumers, {
+            pub async fn consume(&self, mut timeout: Option<&mut Duration>) -> Result<T> {
+                crate::waiter_loop!(&self.consumers, timeout, {
                     let mut buf = self.buf.lock().unwrap();
                     if buf.len() > 0 {
                         let item = buf.pop_front().unwrap();
                         drop(buf);
 
                         self.producers.wake_one();
-                        return item;
+                        return Ok(item);
                     }
-                });
+                })
             }
 
             pub fn len(&self) -> usize {
@@ -82,8 +81,9 @@ mod tests {
             let producer_task = {
                 let queue = queue.clone();
                 crate::task::spawn(async move {
+                    let mut timeout = Some(Duration::from_millis(500));
                     for i in 0..num_items {
-                        queue.produce(i).await;
+                        queue.produce(i, timeout.as_mut()).await.unwrap();
                     }
                 })
             };
@@ -91,7 +91,7 @@ mod tests {
                 let queue = queue.clone();
                 crate::task::spawn(async move {
                     for i in 0..num_items {
-                        assert!(queue.consume().await == i);
+                        assert!(queue.consume(None).await.unwrap() == i);
                     }
                 })
             };
@@ -99,5 +99,89 @@ mod tests {
             producer_task.await;
             consumer_task.await;
         });
+    }
+
+    #[test]
+    fn wait_timeout_err() {
+        crate::task::block_on(async {
+            let ms = 100;
+            let mut timeout = Duration::from_millis(ms);
+            let start = std::time::Instant::now();
+            imagined_blocking_func1(Some(&mut timeout)).await;
+            assert!(timeout.is_zero());
+            assert!(start.elapsed().as_millis() as u64 >= ms - 1);
+
+            let mut timeout = Duration::from_millis(ms);
+            let start = std::time::Instant::now();
+            imagined_blocking_func2(Some(&mut timeout)).await;
+            assert!(timeout.is_zero());
+            assert!(start.elapsed().as_millis() as u64 >= ms - 1);
+
+            // case: timeout less than 1ms.
+            let mut timeout = Duration::from_nanos(10);
+            let start = std::time::Instant::now();
+            imagined_blocking_func1(Some(&mut timeout)).await;
+            assert!(timeout.is_zero());
+            assert!(start.elapsed().as_millis() < 2);
+        });
+    }
+
+    #[test]
+    fn wait_timeout_ok() {
+        crate::task::block_on(async {
+            let waiter = Waiter::new();
+            let waker = waiter.waker();
+
+            let sleep_time = 10;
+            let timeout_time = 100;
+            let join_handle = crate::task::spawn(async move {
+                let mut timeout = Duration::from_millis(timeout_time);
+                assert!(waiter.wait_timeout(Some(&mut timeout)).await.is_ok());
+            });
+
+            crate::sched::yield_().await;
+            std::thread::sleep(Duration::from_millis(sleep_time));
+            waker.wake();
+            join_handle.await;
+        });
+    }
+
+    #[test]
+    fn wait_none() {
+        crate::task::block_on(async {
+            let waiter = Waiter::new();
+            let waker = waiter.waker();
+
+            let join_handle = crate::task::spawn(async move {
+                waiter.wait_timeout::<Duration>(None).await.unwrap();
+            });
+
+            crate::sched::yield_().await;
+            waker.wake();
+            join_handle.await;
+        });
+    }
+
+    async fn imagined_blocking_func1(timeout: Option<&mut Duration>) {
+        assert!(timeout.is_some());
+
+        let waiter = Waiter::new();
+        let res = waiter.wait_timeout(timeout).await;
+
+        // timeout expired.
+        assert!(res.is_err());
+    }
+
+    async fn imagined_blocking_func2(timeout: Option<&mut Duration>) {
+        assert!(timeout.is_some());
+        let mut timeout = timeout.map_or(None, |t| Some(t));
+
+        let waiter = Waiter::new();
+        loop {
+            if let Err(_) = waiter.wait_timeout(timeout.as_mut()).await {
+                // timeout expired, return.
+                break;
+            }
+        }
     }
 }

--- a/src/libos/crates/async-rt/src/wait/waiter_queue.rs
+++ b/src/libos/crates/async-rt/src/wait/waiter_queue.rs
@@ -124,7 +124,7 @@ impl WaiterQueueInner {
 
         // Make sure self.ptr refers to a valid items in the list
         if self.next_ptr.is_none() {
-            let mut cursor = self.list.front_mut();
+            let cursor = self.list.front_mut();
             if cursor.is_null() {
                 return 0;
             }

--- a/src/libos/crates/vdso-time/Cargo.toml
+++ b/src/libos/crates/vdso-time/Cargo.toml
@@ -7,18 +7,25 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["libc"]
-sgx = ["sgx_types", "sgx_tstd", "sgx_libc"]
+default = ["std"]
+std = ["libc"]
+sgx = ["sgx_types", "sgx_tstd", "sgx_libc", "sgx_trts"]
 
 [dependencies]
+cfg-if = "1.0"
+errno = { path = "../errno" }
+lazy_static = { version = "1.4.0", features = ["spin_no_std"] }
 libc = { version = "0.2", optional = true }
+log = "0.4"
 sgx_types = { path = "../../../../deps/rust-sgx-sdk/sgx_types", optional = true }
 sgx_tstd = { path = "../../../../deps/rust-sgx-sdk/sgx_tstd", optional = true, features = ["backtrace"] }
 sgx_libc = { path = "../../../../deps/rust-sgx-sdk/sgx_libc", optional = true }
+sgx_trts = { path = "../../../../deps/rust-sgx-sdk/sgx_trts", optional = true }
 
 [dev-dependencies]
 criterion = "0.3"
 lazy_static = { version = "1.4.0", features = ["spin_no_std"] }
+ctor = "0.1"
 
 [[bench]]
 name = "bench"

--- a/src/libos/crates/vdso-time/README.md
+++ b/src/libos/crates/vdso-time/README.md
@@ -17,50 +17,24 @@ vdso-time = { path = "yourpath/vdso-time", default-features = false, features = 
 ## API examples
 
 ```
-use vdso_time::{time_t, timespec, timeval, timezone, Vdso, CLOCK_REALTIME};
+use vdso_time::ClockId;
 
-// init vdso
+let time = vdso_time::clock_gettime(ClockId::CLOCK_MONOTONIC).unwrap();
+println!("vdso_time::clock_gettime: {:?}", time);
+
+let res = vdso_time::clock_getres(ClockId::CLOCK_MONOTONIC).unwrap();
+println!("vdso_time::clock_getres: {:?}", res);
+```
+
+```
+use vdso_time::{Vdso, ClockId};
+
 let vdso = Vdso::new().unwrap();
 
-// time()
-let mut tloc: time_t = 0;
-let time = vdso.time(&mut tloc as *mut _).unwrap();
-println!("time(): t {}, tloc {}", time, tloc);
+let time = vdso.clock_gettime(ClockId::CLOCK_MONOTONIC).unwrap();
+println!("vdso.clock_gettime: {:?}", time);
 
-// gettimeofday()
-let mut tv = timeval {
-    tv_sec: 0,
-    tv_usec: 0,
-};
-let mut tz = timezone::default();
-vdso.gettimeofday(&mut tv as *mut _, &mut tz as *mut _)
-    .unwrap();
-println!(
-    "gettimeofday(): tv_sec {}, tv_usec {}; tz_minuteswest {}, tz_dsttime {}",
-    tv.tv_sec, tv.tv_usec, tz.tz_minuteswest, tz.tz_dsttime,
-);
-
-// clock_gettime
-let mut tp = timespec {
-    tv_sec: 0,
-    tv_nsec: 0,
-};
-let clockid = CLOCK_REALTIME;
-vdso.clock_gettime(clockid, &mut tp).unwrap();
-println!(
-    "clock_gettime({:?}): tv_sec {}, tv_nsec {}",
-    clockid, tp.tv_sec, tp.tv_nsec
-);
-
-// clock_getres
-let mut tp = timespec {
-    tv_sec: 0,
-    tv_nsec: 0,
-};
-let clockid = CLOCK_REALTIME;
-vdso.clock_getres(clockid, &mut tp).unwrap();
-println!(
-    "clock_getres({:?}): tv_sec {}, tv_nsec {}",
-    clockid, tp.tv_sec, tp.tv_nsec
-);
+let res = vdso.clock_getres(ClockId::CLOCK_MONOTONIC).unwrap();
+println!("vdso.clock_getres: {:?}", res);
+}
 ```

--- a/src/libos/crates/vdso-time/benches/bench.rs
+++ b/src/libos/crates/vdso-time/benches/bench.rs
@@ -1,111 +1,40 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use vdso_time::ClockId;
 
-use lazy_static::lazy_static;
-use vdso_time::{time_t, timespec, timeval, Vdso, CLOCK_REALTIME};
-
-lazy_static! {
-    static ref VDSO: Vdso = Vdso::new().unwrap();
-}
-
-fn linux_time() -> time_t {
-    let mut tloc: time_t = 0;
-    unsafe {
-        libc::time(&mut tloc as *mut _);
-    }
-    tloc
-}
-
-fn vdso_time() -> time_t {
-    let mut tloc: time_t = 0;
-    VDSO.time(&mut tloc as *mut _).unwrap();
-    tloc
-}
-
-fn linux_gettimeofday() -> timeval {
-    let mut tv = timeval {
-        tv_sec: 0,
-        tv_usec: 0,
-    };
-    unsafe {
-        libc::gettimeofday(&mut tv as *mut _, std::ptr::null_mut());
-    }
-    tv
-}
-
-fn vdso_gettimeofday() -> timeval {
-    let mut tv = timeval {
-        tv_sec: 0,
-        tv_usec: 0,
-    };
-    VDSO.gettimeofday(&mut tv as *mut _, std::ptr::null_mut())
-        .unwrap();
-    tv
-}
-
-fn linux_clock_gettime() -> timespec {
-    let mut tp = timespec {
+fn libc_clock_gettime() -> libc::timespec {
+    let mut tp = libc::timespec {
         tv_sec: 0,
         tv_nsec: 0,
     };
-    let clockid = CLOCK_REALTIME;
     unsafe {
-        libc::clock_gettime(clockid, &mut tp as *mut _);
+        libc::clock_gettime(ClockId::CLOCK_MONOTONIC as _, &mut tp as *mut _);
     }
     tp
 }
 
-fn vdso_clock_gettime() -> timespec {
-    let mut tp = timespec {
+fn libc_clock_getres() -> libc::timespec {
+    let mut tp = libc::timespec {
         tv_sec: 0,
         tv_nsec: 0,
     };
-    let clockid = CLOCK_REALTIME;
-    VDSO.clock_gettime(clockid, &mut tp as *mut _).unwrap();
-    tp
-}
-
-fn linux_clock_getres() -> timespec {
-    let mut tp = timespec {
-        tv_sec: 0,
-        tv_nsec: 0,
-    };
-    let clockid = CLOCK_REALTIME;
     unsafe {
-        libc::clock_getres(clockid, &mut tp as *mut _);
+        libc::clock_getres(ClockId::CLOCK_MONOTONIC as _, &mut tp as *mut _);
     }
-    tp
-}
-
-fn vdso_clock_getres() -> timespec {
-    let mut tp = timespec {
-        tv_sec: 0,
-        tv_nsec: 0,
-    };
-    let clockid = CLOCK_REALTIME;
-    VDSO.clock_getres(clockid, &mut tp as *mut _).unwrap();
     tp
 }
 
 fn criterion_benchmark(c: &mut Criterion) {
-    c.bench_function("linux time", |b| b.iter(|| black_box(linux_time())));
-    c.bench_function("vdso time", |b| b.iter(|| black_box(vdso_time())));
-    c.bench_function("linux gettimeofday", |b| {
-        b.iter(|| black_box(linux_gettimeofday()))
-    });
-    c.bench_function("vdso gettimeofday", |b| {
-        b.iter(|| black_box(vdso_gettimeofday()))
-    });
-    c.bench_function("linux clock_gettime", |b| {
-        b.iter(|| black_box(linux_clock_gettime()))
+    c.bench_function("libc clock_gettime", |b| {
+        b.iter(|| black_box(libc_clock_gettime()))
     });
     c.bench_function("vdso clock_gettime", |b| {
-        b.iter(|| black_box(vdso_clock_gettime()))
+        b.iter(|| black_box(vdso_time::clock_gettime(ClockId::CLOCK_MONOTONIC).unwrap()))
     });
-    c.bench_function("linux clock_getres", |b| {
-        b.iter(|| black_box(linux_clock_getres()))
+    c.bench_function("libc clock_getres", |b| {
+        b.iter(|| black_box(libc_clock_getres()))
     });
     c.bench_function("vdso clock_getres", |b| {
-        b.iter(|| black_box(vdso_clock_getres()))
+        b.iter(|| black_box(vdso_time::clock_getres(ClockId::CLOCK_MONOTONIC).unwrap()))
     });
 }
 

--- a/src/libos/crates/vdso-time/examples/bench.rs
+++ b/src/libos/crates/vdso-time/examples/bench.rs
@@ -1,56 +1,33 @@
 include!("common/bench.rs");
 
-fn linux_time() -> u64 {
-    let mut tloc: time_t = 0;
-    unsafe {
-        libc::time(&mut tloc as *mut _);
-    }
-    tloc as u64
-}
-
-fn linux_gettimeofday() -> u64 {
-    let mut tv = timeval {
-        tv_sec: 0,
-        tv_usec: 0,
-    };
-    unsafe {
-        libc::gettimeofday(&mut tv as *mut _, std::ptr::null_mut());
-    }
-    tv.tv_sec as u64 * 1000000 + tv.tv_usec as u64
-}
-
-fn linux_clock_gettime() -> u64 {
-    let mut tp = timespec {
+fn libc_clock_gettime() -> Duration {
+    let mut tp = libc::timespec {
         tv_sec: 0,
         tv_nsec: 0,
     };
-    let clockid = CLOCK_REALTIME;
     unsafe {
-        libc::clock_gettime(clockid, &mut tp as *mut _);
+        libc::clock_gettime(ClockId::CLOCK_MONOTONIC as _, &mut tp as *mut _);
     }
-    tp.tv_sec as u64 * 1000000000 + tp.tv_nsec as u64
+    Duration::new(tp.tv_sec as u64, tp.tv_nsec as u32)
 }
 
-fn linux_clock_getres() -> u64 {
-    let mut tp = timespec {
+fn libc_clock_getres() -> Duration {
+    let mut tp = libc::timespec {
         tv_sec: 0,
         tv_nsec: 0,
     };
-    let clockid = CLOCK_REALTIME;
     unsafe {
-        libc::clock_getres(clockid, &mut tp as *mut _);
+        libc::clock_getres(ClockId::CLOCK_MONOTONIC as _, &mut tp as *mut _);
     }
-    tp.tv_sec as u64 * 1000000000 + tp.tv_nsec as u64
+    Duration::new(tp.tv_sec as u64, tp.tv_nsec as u32)
 }
 
-fn linux_benchmarks() {
-    benchmark("Linux time()", linux_time);
-    benchmark("Linux gettimeofday()", linux_gettimeofday);
-    benchmark("Linux clock_gettime()", linux_clock_gettime);
-    benchmark("Linux clock_getres()", linux_clock_getres);
+fn libc_benchmarks() {
+    benchmark("Libc clock_gettime()", libc_clock_gettime);
+    benchmark("Libc clock_getres()", libc_clock_getres);
 }
 
 fn main() {
-    linux_benchmarks();
+    libc_benchmarks();
     vdso_benchmarks();
 }

--- a/src/libos/crates/vdso-time/examples/common/example.rs
+++ b/src/libos/crates/vdso-time/examples/common/example.rs
@@ -1,43 +1,26 @@
-fn example() {
-    use vdso_time::{time_t, timespec, timeval, timezone, Vdso, CLOCK_REALTIME};
+fn first_example() {
+    use vdso_time::ClockId;
+
+    let time = vdso_time::clock_gettime(ClockId::CLOCK_MONOTONIC).unwrap();
+    println!("vdso_time::clock_gettime: {:?}", time);
+
+    let res = vdso_time::clock_getres(ClockId::CLOCK_MONOTONIC).unwrap();
+    println!("vdso_time::clock_getres: {:?}", res);
+}
+
+fn second_example() {
+    use vdso_time::{Vdso, ClockId};
 
     let vdso = Vdso::new().unwrap();
 
-    let mut tloc: time_t = 0;
-    let time = vdso.time(&mut tloc as *mut _).unwrap();
-    println!("time(): t {}, tloc {}", time, tloc);
+    let time = vdso.clock_gettime(ClockId::CLOCK_MONOTONIC).unwrap();
+    println!("vdso.clock_gettime: {:?}", time);
 
-    let mut tv = timeval {
-        tv_sec: 0,
-        tv_usec: 0,
-    };
-    let mut tz = timezone::default();
-    vdso.gettimeofday(&mut tv as *mut _, &mut tz as *mut _)
-        .unwrap();
-    println!(
-        "gettimeofday(): tv_sec {}, tv_usec {}; tz_minuteswest {}, tz_dsttime {}",
-        tv.tv_sec, tv.tv_usec, tz.tz_minuteswest, tz.tz_dsttime,
-    );
+    let res = vdso.clock_getres(ClockId::CLOCK_MONOTONIC).unwrap();
+    println!("vdso.clock_getres: {:?}", res);
+}
 
-    let mut tp = timespec {
-        tv_sec: 0,
-        tv_nsec: 0,
-    };
-    let clockid = CLOCK_REALTIME;
-    vdso.clock_gettime(clockid, &mut tp).unwrap();
-    println!(
-        "clock_gettime({:?}): tv_sec {}, tv_nsec {}",
-        clockid, tp.tv_sec, tp.tv_nsec
-    );
-
-    let mut tp = timespec {
-        tv_sec: 0,
-        tv_nsec: 0,
-    };
-    let clockid = CLOCK_REALTIME;
-    vdso.clock_getres(clockid, &mut tp).unwrap();
-    println!(
-        "clock_getres({:?}): tv_sec {}, tv_nsec {}",
-        clockid, tp.tv_sec, tp.tv_nsec
-    );
+fn example() {
+    first_example();
+    second_example();
 }

--- a/src/libos/crates/vdso-time/ocalls/sgx_vdso_time_ocalls.edl
+++ b/src/libos/crates/vdso-time/ocalls/sgx_vdso_time_ocalls.edl
@@ -3,13 +3,12 @@ enclave {
 
     untrusted {
         int vdso_ocall_get_vdso_info(
-            [out] unsigned long* vdso_addr, 
-            [out] long* hres_resolution, 
-            [out] long* coarse_resolution, 
+            [out] unsigned long* vdso_addr,
             [out, size = release_len] char* release,
-            int release_len,
-            [out, count = tss_len] struct timespec* tss,
-            int tss_len
+            int release_len
         );
+
+        int vdso_ocall_clock_gettime(int clockid, [out] struct timespec* ts);
+        int vdso_ocall_clock_getres(int clockid, [out] struct timespec* res);
     };
 };

--- a/src/libos/crates/vdso-time/src/lib.rs
+++ b/src/libos/crates/vdso-time/src/lib.rs
@@ -1,6 +1,4 @@
 #![cfg_attr(feature = "sgx", no_std)]
-#![feature(asm)]
-#![feature(llvm_asm)]
 
 #[cfg(feature = "sgx")]
 extern crate sgx_types;
@@ -9,289 +7,287 @@ extern crate sgx_types;
 extern crate sgx_tstd as std;
 #[cfg(feature = "sgx")]
 extern crate sgx_libc as libc;
+#[cfg(feature = "sgx")]
+extern crate sgx_trts;
 
 mod sys;
 
-pub use libc::{
-    clockid_t, time_t, timespec, timeval, CLOCK_BOOTTIME, CLOCK_MONOTONIC, CLOCK_MONOTONIC_COARSE,
-    CLOCK_MONOTONIC_RAW, CLOCK_REALTIME, CLOCK_REALTIME_COARSE,
-};
+use errno::prelude::*;
+use lazy_static::lazy_static;
+use log::trace;
+use std::convert::TryFrom;
 use std::str;
-use std::sync::atomic::{self, Ordering};
-pub use sys::timezone;
+use std::time::Duration;
 use sys::*;
 
+pub const NANOS_PER_SEC: u32 = 1_000_000_000;
+pub const NANOS_PER_MILLI: u32 = 1_000_000;
+pub const NANOS_PER_MICRO: u32 = 1_000;
+pub const MILLIS_PER_SEC: u64 = 1_000;
+pub const MICROS_PER_SEC: u64 = 1_000_000;
+
+/// Clocks supported by the linux kernel, corresponding to clockid_t in Linux.
+#[derive(Debug, Eq, PartialEq, Copy, Clone)]
+#[allow(non_camel_case_types)]
+pub enum ClockId {
+    CLOCK_REALTIME = 0,
+    CLOCK_MONOTONIC = 1,
+    // vDSO doesn't support CLOCK_PROCESS_CPUTIME_ID.
+    CLOCK_PROCESS_CPUTIME_ID = 2,
+    // vDSO doesn't support CLOCK_THREAD_CPUTIME_ID.
+    CLOCK_THREAD_CPUTIME_ID = 3,
+    CLOCK_MONOTONIC_RAW = 4,
+    CLOCK_REALTIME_COARSE = 5,
+    CLOCK_MONOTONIC_COARSE = 6,
+    CLOCK_BOOTTIME = 7,
+}
+
+impl TryFrom<i32> for ClockId {
+    type Error = Error;
+
+    fn try_from(clockid: i32) -> Result<Self> {
+        Ok(match clockid {
+            0 => ClockId::CLOCK_REALTIME,
+            1 => ClockId::CLOCK_MONOTONIC,
+            2 => ClockId::CLOCK_PROCESS_CPUTIME_ID,
+            3 => ClockId::CLOCK_THREAD_CPUTIME_ID,
+            4 => ClockId::CLOCK_MONOTONIC_RAW,
+            5 => ClockId::CLOCK_REALTIME_COARSE,
+            6 => ClockId::CLOCK_MONOTONIC_COARSE,
+            7 => ClockId::CLOCK_BOOTTIME,
+            _ => return_errno!(EINVAL, "Unsupported clockid"),
+        })
+    }
+}
+
+/// An abstraction of Linux vDSO provides the clock and time interface through Linux vDSO.
 pub struct Vdso {
     vdso_data_ptr: VdsoDataPtr,
     // hres resolution for clock_getres
-    hres_resolution: Option<i64>,
+    hres_resolution: Option<Duration>,
     // coarse resolution for clock_getres
-    coarse_resolution: Option<i64>,
-    // If support_clocks[clockid] is true, indicate that the corresponding clockid is supported
-    support_clocks: [bool; VDSO_BASES],
+    coarse_resolution: Option<Duration>,
 }
 
 impl Vdso {
-    pub fn new() -> Result<Self, ()> {
-        let mut support_clocks = [false; VDSO_BASES];
-        let clockids = [
-            CLOCK_REALTIME,
-            CLOCK_MONOTONIC,
-            CLOCK_MONOTONIC_RAW,
-            CLOCK_REALTIME_COARSE,
-            CLOCK_MONOTONIC_COARSE,
-            CLOCK_BOOTTIME,
-        ];
-
-        #[cfg(not(feature = "sgx"))]
-        let (vdso_addr, hres_resolution, coarse_resolution, tss, release) = {
-            const AT_SYSINFO_EHDR: u64 = 33;
-            let vdso_addr = unsafe { libc::getauxval(AT_SYSINFO_EHDR) };
-
-            let mut tp = timespec {
-                tv_sec: 0,
-                tv_nsec: 0,
-            };
-            let ret = unsafe { libc::clock_getres(CLOCK_REALTIME, &mut tp as *mut _) };
-            let hres_resolution = if ret == 0 { Some(tp.tv_nsec) } else { None };
-            let ret = unsafe { libc::clock_getres(CLOCK_REALTIME_COARSE, &mut tp as *mut _) };
-            let coarse_resolution = if ret == 0 { Some(tp.tv_nsec) } else { None };
-
-            let mut utsname: libc::utsname = unsafe { std::mem::zeroed() };
-            let ret = unsafe { libc::uname(&mut utsname as *mut _) };
-            if ret != 0 {
-                return Err(());
-            }
-
-            let mut tss = [timespec {
-                tv_sec: 0,
-                tv_nsec: 0,
-            }; VDSO_BASES as usize];
-            for &clockid in &clockids {
-                unsafe {
-                    if libc::clock_gettime(clockid, &mut tss[clockid as usize] as *mut _) != 0 {
-                        tss[clockid as usize].tv_sec = 0;
-                        tss[clockid as usize].tv_nsec = 0;
-                    }
-                }
-            }
-
-            (
-                vdso_addr,
-                hres_resolution,
-                coarse_resolution,
-                tss,
-                utsname.release,
-            )
+    /// Try to create a new Vdso by libc or SGX OCALL.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use vdso_time::Vdso;
+    /// let vdso = Vdso::new().unwrap();
+    /// ```
+    pub fn new() -> Result<Self> {
+        let vdso_data_ptr = Self::get_vdso_data_ptr_from_host()?;
+        let hres_resolution = clock_getres_slow(ClockId::CLOCK_MONOTONIC).ok();
+        let coarse_resolution = clock_getres_slow(ClockId::CLOCK_MONOTONIC_COARSE).ok();
+        let vdso = Self {
+            vdso_data_ptr,
+            hres_resolution,
+            coarse_resolution,
         };
+        vdso.check_accuracy()?;
+        Ok(vdso)
+    }
+
+    #[cfg(feature = "sgx")]
+    fn get_vdso_data_ptr_from_host() -> Result<VdsoDataPtr> {
+        extern "C" {
+            fn vdso_ocall_get_vdso_info(
+                ret: *mut libc::c_int,
+                vdso_addr: *mut libc::c_ulong,
+                release: *mut libc::c_char,
+                release_len: libc::c_int,
+            ) -> sgx_types::sgx_status_t;
+        }
+
+        let mut vdso_addr: libc::c_ulong = 0;
+        let mut release = [0 as libc::c_char; 65];
+        let mut ret: libc::c_int = 0;
+        unsafe {
+            vdso_ocall_get_vdso_info(
+                &mut ret as *mut _,
+                &mut vdso_addr as *mut _,
+                release.as_mut_ptr(),
+                release.len() as _,
+            );
+        }
+        if ret != 0 {
+            return_errno!(EINVAL, "Vdso vdso_ocall_get_vdso_info() failed")
+        }
+
+        Self::match_kernel_version(vdso_addr, &release)
+    }
+
+    #[cfg(not(feature = "sgx"))]
+    fn get_vdso_data_ptr_from_host() -> Result<VdsoDataPtr> {
+        const AT_SYSINFO_EHDR: u64 = 33;
+        let vdso_addr = unsafe { libc::getauxval(AT_SYSINFO_EHDR) };
+
+        let mut utsname: libc::utsname = unsafe { std::mem::zeroed() };
+        let ret = unsafe { libc::uname(&mut utsname as *mut _) };
+        if ret != 0 {
+            return_errno!(EINVAL, "Vdso get utsname failed");
+        }
+        let release = utsname.release;
+
+        Self::match_kernel_version(vdso_addr, &release)
+    }
+
+    fn check_vdso_addr(vdso_addr: &u64) -> Result<()> {
+        let vdso_addr = *vdso_addr;
+        if vdso_addr == 0 {
+            return_errno!(EFAULT, "Vdso vdso_addr is 0")
+        }
+        const VDSO_DATA_MAX_SIZE: u64 = 4 * PAGE_SIZE;
+        if vdso_addr < VDSO_DATA_MAX_SIZE {
+            return_errno!(EFAULT, "Vdso vdso_addr is less than vdso data size");
+        }
 
         #[cfg(feature = "sgx")]
-        let (vdso_addr, hres_resolution, coarse_resolution, tss, release) = {
-            extern "C" {
-                fn vdso_ocall_get_vdso_info(
-                    ret: *mut libc::c_int,
-                    vdso_addr: *mut libc::c_ulong,
-                    hres_resolution: *mut libc::c_long,
-                    coarse_resolution: *mut libc::c_long,
-                    release: *mut libc::c_char,
-                    release_len: libc::c_int,
-                    tss: *mut timespec,
-                    tss_len: libc::c_int,
-                ) -> sgx_types::sgx_status_t;
-            }
-
-            let mut vdso_addr: libc::c_ulong = 0;
-            let mut hres_resolution: libc::c_long = 0;
-            let mut coarse_resolution: libc::c_long = 0;
-            let mut release = [0 as libc::c_char; 65];
-            let mut tss = [timespec {
-                tv_sec: 0,
-                tv_nsec: 0,
-            }; VDSO_BASES as usize];
-            let mut ret: libc::c_int = 0;
-            unsafe {
-                vdso_ocall_get_vdso_info(
-                    &mut ret as *mut _,
-                    &mut vdso_addr as *mut _,
-                    &mut hres_resolution as *mut _,
-                    &mut coarse_resolution as *mut _,
-                    release.as_mut_ptr(),
-                    release.len() as _,
-                    tss.as_mut_ptr(),
-                    tss.len() as _,
-                );
-            }
-            if ret != 0 {
-                return Err(());
-            }
-
-            let hres_resolution = if hres_resolution != 0 {
-                Some(hres_resolution)
-            } else {
-                None
-            };
-            let coarse_resolution = if coarse_resolution != 0 {
-                Some(coarse_resolution)
-            } else {
-                None
-            };
-
-            (vdso_addr, hres_resolution, coarse_resolution, tss, release)
-        };
-
-        if vdso_addr == 0 {
-            return Err(());
+        if !sgx_trts::trts::rsgx_raw_is_outside_enclave(
+            (vdso_addr - VDSO_DATA_MAX_SIZE) as *const u8,
+            VDSO_DATA_MAX_SIZE as _,
+        ) {
+            return_errno!(EFAULT, "Vdso vdso_addr we got is not outside enclave")
         }
+
+        Ok(())
+    }
+
+    fn match_kernel_version(vdso_addr: u64, release: &[libc::c_char]) -> Result<VdsoDataPtr> {
+        Self::check_vdso_addr(&vdso_addr)?;
 
         // release, e.g., "5.9.6-050906-generic"
-        let release = unsafe { &*(&release as *const [i8] as *const [u8]) };
+        let release = unsafe { &*(release as *const [i8] as *const [u8]) };
         let release = str::from_utf8(release);
         if release.is_err() {
-            return Err(());
+            return_errno!(EINVAL, "Vdso get kernel release failed")
         }
         let mut release = release.unwrap().split(&['-', '.', ' '][..]);
-        let version_big: u8 = release.next().unwrap_or("0").parse().unwrap_or(0);
-        let version_little: u8 = release.next().unwrap_or("0").parse().unwrap_or(0);
+        let version_big: u8 = release
+            .next()
+            .ok_or(errno!(EINVAL, "Vdso get kernel big version failed"))?
+            .parse()?;
+        let version_little: u8 = release
+            .next()
+            .ok_or(errno!(EINVAL, "Vdso get kernel little version failed"))?
+            .parse()?;
 
-        let vdso_data_ptr = match (version_big, version_little) {
+        Ok(match (version_big, version_little) {
             (4, 0..=4) | (4, 7..=11) => VdsoDataPtr::V4_0(vdso_data_v4_0::vdsodata_ptr(vdso_addr)),
             (4, 5..=6) | (4, 12..=19) => VdsoDataPtr::V4_5(vdso_data_v4_5::vdsodata_ptr(vdso_addr)),
             (5, 0..=2) => VdsoDataPtr::V5_0(vdso_data_v5_0::vdsodata_ptr(vdso_addr)),
             (5, 3..=5) => VdsoDataPtr::V5_3(vdso_data_v5_3::vdsodata_ptr(vdso_addr)),
             (5, 6..=8) => VdsoDataPtr::V5_6(vdso_data_v5_6::vdsodata_ptr(vdso_addr)),
-            (5, _) => VdsoDataPtr::V5_9(vdso_data_v5_9::vdsodata_ptr(vdso_addr)),
-            (_, _) => return Err(()),
-        };
+            (5, 9..=12) => VdsoDataPtr::V5_9(vdso_data_v5_9::vdsodata_ptr(vdso_addr)),
+            (_, _) => return_errno!(EINVAL, "Vdso match kernel release failed"),
+        })
+    }
 
-        // If linux support a clockid, then we think vdso support it too temporaryly.
-        // We will verify whether vdso can support this clockid correctly later.
-        for &clockid in &clockids {
-            if !(tss[clockid as usize].tv_sec == 0 && tss[clockid as usize].tv_nsec == 0) {
-                support_clocks[clockid as usize] = true;
-            }
-        }
-
-        let mut vdso = Self {
-            vdso_data_ptr,
-            hres_resolution,
-            coarse_resolution,
-            support_clocks,
-        };
-
-        // Compare the results of Linux and vdso
-        // to check whether vdso can support the clockid correctly.
-        for &clockid in &clockids {
-            if vdso.support_clocks[clockid as usize] {
-                let mut tp = timespec {
-                    tv_sec: 0,
-                    tv_nsec: 0,
+    /// Compare the results of Linux syscall and vdso to check whether vdso can support the clockid correctly.
+    fn check_accuracy(&self) -> Result<()> {
+        let vdso_supported_clockids = [
+            ClockId::CLOCK_REALTIME,
+            ClockId::CLOCK_MONOTONIC,
+            ClockId::CLOCK_MONOTONIC_RAW,
+            ClockId::CLOCK_REALTIME_COARSE,
+            ClockId::CLOCK_MONOTONIC_COARSE,
+            ClockId::CLOCK_BOOTTIME,
+        ];
+        const MAX_INACCURACY: Duration = Duration::from_millis(1);
+        const MAX_RETRY_NUM: u32 = 3;
+        for &clockid in vdso_supported_clockids.iter() {
+            for retry_num in 0..MAX_RETRY_NUM {
+                let time = match self.do_clock_gettime(clockid) {
+                    Ok(time) => time,
+                    Err(_) => break,
                 };
-                if vdso.clock_gettime(clockid, &mut tp as *mut _).is_err() {
-                    vdso.support_clocks[clockid as usize] = false;
+
+                let host_time = match clock_gettime_slow(clockid) {
+                    Ok(host_time) => host_time,
+                    Err(_) => break,
+                };
+
+                let estimated_inaccuracy = match host_time.checked_sub(time) {
+                    Some(diff) => diff,
+                    None => return_errno!(EOPNOTSUPP, "Vdso can not provide valid time"),
+                };
+                if estimated_inaccuracy > MAX_INACCURACY {
+                    if retry_num == MAX_RETRY_NUM - 1 {
+                        return_errno!(EOPNOTSUPP, "Vdso reached max retey number");
+                    }
+                    continue;
                 }
-                let diff = (tp.tv_sec - tss[clockid as usize].tv_sec) * NSEC_PER_SEC as i64
-                    + (tp.tv_nsec - tss[clockid as usize].tv_nsec);
-                if diff < 0 || diff > 10000 * NSEC_PER_USEC as i64 {
-                    vdso.support_clocks[clockid as usize] = false;
-                }
+                trace!("Vdso support clock {:?}", clockid);
+                break;
             }
         }
-
-        Ok(vdso)
+        trace!("Vdso passed check, init succeeded");
+        Ok(())
     }
 
-    // Linux time(): time_t time(time_t *tloc);
-    pub fn time(&self, tloc: *mut time_t) -> Result<time_t, ()> {
-        let clockid = CLOCK_REALTIME;
-        if !self.support_clocks[clockid as usize] {
-            return Err(());
-        }
-
-        let vdso_data = self.vdso_data(ClockSource::CS_HRES_COARSE);
-        let t: time_t = vdso_data.sec(clockid)? as _;
-        if !tloc.is_null() {
-            unsafe {
-                *tloc = t;
-            }
-        }
-        Ok(t)
+    /// Try to get time according to ClockId.
+    /// Firstly try to get time through vDSO, if failed, then try fallback.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use vdso_time::{Vdso, ClockId};
+    /// let vdso = Vdso::new().unwrap();
+    /// let time = vdso.clock_gettime(ClockId::CLOCK_MONOTONIC).unwrap();
+    /// println!("{:?}", time);
+    /// ```
+    pub fn clock_gettime(&self, clockid: ClockId) -> Result<Duration> {
+        self.do_clock_gettime(clockid)
+            .or_else(|_| clock_gettime_slow(clockid))
     }
 
-    // Linux gettimeofday(): int gettimeofday(struct timeval *tv, struct timezone *tz);
-    pub fn gettimeofday(&self, tv: *mut timeval, tz: *mut timezone) -> Result<i32, ()> {
-        let clockid = CLOCK_REALTIME;
-        if !self.support_clocks[clockid as usize] {
-            return Err(());
-        }
-
-        if !tv.is_null() {
-            let mut tp = timespec {
-                tv_sec: 0,
-                tv_nsec: 0,
-            };
-            self.do_hres(ClockSource::CS_HRES_COARSE, clockid, &mut tp)?;
-            unsafe {
-                (*tv).tv_sec = tp.tv_sec;
-                (*tv).tv_usec = tp.tv_nsec / NSEC_PER_USEC as i64;
-            }
-        }
-
-        if !tz.is_null() {
-            let vdso_data = self.vdso_data(ClockSource::CS_HRES_COARSE);
-            unsafe {
-                (*tz).tz_minuteswest = vdso_data.tz_minuteswest();
-                (*tz).tz_dsttime = vdso_data.tz_dsttime();
-            }
-        }
-
-        Ok(0)
+    /// Try to get time resolution according to ClockId.
+    /// Firstly try to return resolution inside self, if failed, then try fallback.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use vdso_time::{Vdso, ClockId};
+    /// let vdso = Vdso::new().unwrap();
+    /// let res = vdso.clock_getres(ClockId::CLOCK_MONOTONIC).unwrap();
+    /// println!("{:?}", res);
+    /// ```
+    pub fn clock_getres(&self, clockid: ClockId) -> Result<Duration> {
+        self.do_clock_getres(clockid)
+            .or_else(|_| clock_getres_slow(clockid))
     }
 
-    // Linux clock_gettime(): int clock_gettime(clockid_t clockid, struct timespec *tp);
-    pub fn clock_gettime(&self, clockid: clockid_t, tp: *mut timespec) -> Result<i32, ()> {
-        if !self.support_clocks[clockid as usize] {
-            return Err(());
-        }
-
+    fn do_clock_gettime(&self, clockid: ClockId) -> Result<Duration> {
         match clockid {
-            CLOCK_REALTIME | CLOCK_MONOTONIC | CLOCK_BOOTTIME => {
-                self.do_hres(ClockSource::CS_HRES_COARSE, clockid, tp)
+            ClockId::CLOCK_REALTIME | ClockId::CLOCK_MONOTONIC | ClockId::CLOCK_BOOTTIME => {
+                self.do_hres(ClockSource::CS_HRES_COARSE, clockid)
             }
-            CLOCK_MONOTONIC_RAW => self.do_hres(ClockSource::CS_RAW, clockid, tp),
-            CLOCK_REALTIME_COARSE | CLOCK_MONOTONIC_COARSE => {
-                self.do_coarse(ClockSource::CS_HRES_COARSE, clockid, tp)
+            ClockId::CLOCK_MONOTONIC_RAW => self.do_hres(ClockSource::CS_RAW, clockid),
+            ClockId::CLOCK_REALTIME_COARSE | ClockId::CLOCK_MONOTONIC_COARSE => {
+                self.do_coarse(ClockSource::CS_HRES_COARSE, clockid)
             }
-            _ => Err(()),
+            _ => return_errno!(EINVAL, "Unsupported clockid in do_clock_gettime()"),
         }
     }
 
-    // Linux clock_getres(): int clock_getres(clockid_t clockid, struct timespec *res);
-    pub fn clock_getres(&self, clockid: clockid_t, res: *mut timespec) -> Result<i32, ()> {
-        let ns = match clockid {
-            CLOCK_REALTIME | CLOCK_MONOTONIC | CLOCK_BOOTTIME | CLOCK_MONOTONIC_RAW => {
-                if self.hres_resolution.is_none() {
-                    return Err(());
-                }
-                self.hres_resolution.unwrap()
-            }
-            CLOCK_REALTIME_COARSE | CLOCK_MONOTONIC_COARSE => {
-                if self.coarse_resolution.is_none() {
-                    return Err(());
-                }
-                self.coarse_resolution.unwrap()
-            }
-            _ => return Err(()),
-        };
-
-        unsafe {
-            (*res).tv_sec = 0;
-            (*res).tv_nsec = ns;
+    fn do_clock_getres(&self, clockid: ClockId) -> Result<Duration> {
+        match clockid {
+            ClockId::CLOCK_REALTIME
+            | ClockId::CLOCK_MONOTONIC
+            | ClockId::CLOCK_BOOTTIME
+            | ClockId::CLOCK_MONOTONIC_RAW => self
+                .hres_resolution
+                .ok_or(errno!(EOPNOTSUPP, "hres_resolution is none")),
+            ClockId::CLOCK_REALTIME_COARSE | ClockId::CLOCK_MONOTONIC_COARSE => self
+                .coarse_resolution
+                .ok_or(errno!(EOPNOTSUPP, "coarse_resolution is none")),
+            _ => return_errno!(EINVAL, "Unsupported clockid in do_clock_getres()"),
         }
-
-        Ok(0)
     }
 
-    #[inline]
     fn vdso_data(&self, cs: ClockSource) -> &'static dyn VdsoData {
         match self.vdso_data_ptr {
             VdsoDataPtr::V4_0(ptr) => unsafe { &*(ptr) },
@@ -303,243 +299,324 @@ impl Vdso {
         }
     }
 
-    fn do_hres(&self, cs: ClockSource, clockid: clockid_t, tp: *mut timespec) -> Result<i32, ()> {
+    fn do_hres(&self, cs: ClockSource, clockid: ClockId) -> Result<Duration> {
         let vdso_data = self.vdso_data(cs);
         loop {
             let seq = vdso_data.seq();
-
-            atomic::fence(Ordering::Acquire);
-
-            if vdso_data.clock_mode() == vdso_clock_mode::VDSO_CLOCKMODE_NONE as i32 {
-                return Err(());
+            // if seq is odd, it might means that a concurrent update is in progress.
+            // Hence, we do some instructions to spin waiting for seq to become even again.
+            if seq & 1 != 0 {
+                core::sync::atomic::spin_loop_hint();
+                continue;
             }
 
-            let cycles = {
-                let upper: u64;
-                let lower: u64;
-                unsafe {
-                    llvm_asm!("rdtscp"
-                         : "={rax}"(lower),
-                           "={rdx}"(upper)
-                         :
-                         :
-                         : "volatile"
-                    );
-                }
-                upper << 32 | lower
-            };
+            // Make sure that all prior load-from-memory instructions have completed locally,
+            // and no later instruction begins execution until LFENCE completes.
+            // We want to make sure the execution order as followning:
+            //     seq -> [cycles, cycle_last, mult, shift, sec, secs] -> seq
+            // This LFENCE can ensure that the first seq is before [cycles, cycle_last, mult, shift, sec, secs]
+            lfence();
 
-            let sec = vdso_data.sec(clockid)?;
-            let mut ns = vdso_data.nsec(clockid)?;
-            ns += ((cycles - vdso_data.cycle_last()) & vdso_data.mask()) * vdso_data.mult() as u64;
-            ns = ns >> vdso_data.shift();
+            // Get hardware counter according to vdso_data's clock_mode.
+            let cycles = Self::get_hw_counter(vdso_data)?;
+
+            let cycle_last = vdso_data.cycle_last();
+            let mult = vdso_data.mult();
+            let shift = vdso_data.shift();
+            let secs = vdso_data.sec(clockid as _)?;
+            let mut nanos = vdso_data.nsec(clockid as _)?;
 
             if !Self::vdso_read_retry(vdso_data, seq) {
-                unsafe {
-                    (*tp).tv_sec = (sec + ns / NSEC_PER_SEC) as i64;
-                    (*tp).tv_nsec = (ns % NSEC_PER_SEC) as i64;
+                // On x86 arch, the TSC can be slightly off across sockets,
+                // which might cause cycles < cycle_last. Since they are u64 type,
+                // cycles - cycle_last will panic in this case.
+                // Hence we need to verify that cycles is greater than cycle_last.
+                // If not then just use cycle_last, which is the base time of the
+                // current conversion period.
+                // And the vdso mask is always u64_MAX on x86, we don't need use mask.
+                if cycles > cycle_last {
+                    nanos += (cycles - cycle_last) * mult as u64
                 }
-                break;
+                nanos = nanos >> shift;
+
+                return Ok(Duration::new(secs, nanos as u32));
             }
         }
-        Ok(0)
     }
 
-    fn do_coarse(&self, cs: ClockSource, clockid: clockid_t, tp: *mut timespec) -> Result<i32, ()> {
+    fn do_coarse(&self, cs: ClockSource, clockid: ClockId) -> Result<Duration> {
         let vdso_data = self.vdso_data(cs);
         loop {
             let seq = vdso_data.seq();
-
-            atomic::fence(Ordering::Acquire);
-
-            unsafe {
-                (*tp).tv_sec = vdso_data.sec(clockid)? as i64;
-                (*tp).tv_nsec = vdso_data.nsec(clockid)? as i64;
+            // see comments in do_hres
+            if seq & 1 != 0 {
+                core::sync::atomic::spin_loop_hint();
+                continue;
             }
+
+            // see comments in do_hres
+            lfence();
+
+            let secs = vdso_data.sec(clockid as _)?;
+            let nanos = vdso_data.nsec(clockid as _)?;
 
             if !Self::vdso_read_retry(vdso_data, seq) {
-                break;
+                return Ok(Duration::new(secs, nanos as u32));
             }
         }
-        Ok(0)
     }
 
-    #[inline]
     fn vdso_read_retry(vdso_data: &dyn VdsoData, old_seq: u32) -> bool {
-        atomic::fence(Ordering::Acquire);
+        // Make sure that all prior load-from-memory instructions have completed locally,
+        // and no later instruction begins execution until LFENCE completes
+        lfence();
+
         old_seq != vdso_data.seq()
+    }
+
+    fn get_hw_counter(vdso_data: &dyn VdsoData) -> Result<u64> {
+        let clock_mode = vdso_data.clock_mode();
+        if clock_mode == VdsoClockMode::VDSO_CLOCKMODE_TSC as i32 {
+            return Ok(rdtsc_ordered());
+        } else if clock_mode == VdsoClockMode::VDSO_CLOCKMODE_PVCLOCK as i32 {
+            // TODO: support pvclock
+            return_errno!(
+                EOPNOTSUPP,
+                "VDSO_CLOCKMODE_PVCLOCK support is not implemented"
+            );
+        } else if clock_mode == VdsoClockMode::VDSO_CLOCKMODE_HVCLOCK as i32 {
+            // TODO: support hvclock
+            return_errno!(
+                EOPNOTSUPP,
+                "VDSO_CLOCKMODE_HVCLOCK support is not implemented"
+            );
+        } else if clock_mode == VdsoClockMode::VDSO_CLOCKMODE_TIMENS as i32 {
+            // TODO: support timens
+            return_errno!(
+                EOPNOTSUPP,
+                "VDSO_CLOCKMODE_TIMENS support is not implemented"
+            );
+        } else if clock_mode == VdsoClockMode::VDSO_CLOCKMODE_NONE as i32 {
+            // In x86 Linux, the clock_mode will never be VDSO_CLOCKMODE_NONE.
+            return_errno!(EINVAL, "The clock_mode must not be VDSO_CLOCKMODE_NONE");
+        }
+        return_errno!(EINVAL, "Unsupported clock_mode");
     }
 }
 
 unsafe impl Sync for Vdso {}
 unsafe impl Send for Vdso {}
 
+lazy_static! {
+    static ref VDSO: Option<Vdso> = Vdso::new().map_or_else(
+        |e| {
+            trace!("{}", e);
+            None
+        },
+        |v| Some(v)
+    );
+}
+
+/// Try to get time according to ClockId.
+/// Firstly try to get time through vDSO, if failed, then try fallback.
+///
+/// # Examples
+///
+/// ```
+/// use vdso_time::ClockId;
+///
+/// let time = vdso_time::clock_gettime(ClockId::CLOCK_MONOTONIC).unwrap();
+/// println!("{:?}", time);
+/// ```
+pub fn clock_gettime(clockid: ClockId) -> Result<Duration> {
+    if VDSO.is_none() {
+        clock_gettime_slow(clockid)
+    } else {
+        VDSO.as_ref().unwrap().clock_gettime(clockid)
+    }
+}
+
+/// Try to get time resolution according to ClockId.
+/// Firstly try to get time through vDSO, if failed, then try fallback.
+///
+/// # Examples
+///
+/// ```
+/// use vdso_time::ClockId;
+///
+/// let time = vdso_time::clock_getres(ClockId::CLOCK_MONOTONIC).unwrap();
+/// println!("{:?}", time);
+/// ```
+pub fn clock_getres(clockid: ClockId) -> Result<Duration> {
+    if VDSO.is_none() {
+        clock_getres_slow(clockid)
+    } else {
+        VDSO.as_ref().unwrap().clock_getres(clockid)
+    }
+}
+
+fn clock_gettime_slow(clockid: ClockId) -> Result<Duration> {
+    let mut ts = libc::timespec {
+        tv_sec: 0,
+        tv_nsec: 0,
+    };
+
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "sgx")] {
+            extern "C" {
+                fn vdso_ocall_clock_gettime(
+                    ret: *mut libc::c_int,
+                    clockid: libc::c_int,
+                    ts: *mut libc::timespec,
+                ) -> sgx_types::sgx_status_t;
+            }
+            let mut ret: libc::c_int = 0;
+            unsafe {
+                vdso_ocall_clock_gettime(&mut ret as *mut _, clockid as _, &mut ts as *mut _);
+            }
+        } else {
+            let ret = unsafe { libc::clock_gettime(clockid as _, &mut ts as *mut _) };
+        }
+    }
+
+    if ret == 0 {
+        Ok(Duration::new(ts.tv_sec as u64, ts.tv_nsec as u32))
+    } else {
+        return_errno!(EINVAL, "clock_gettime_slow failed")
+    }
+}
+
+fn clock_getres_slow(clockid: ClockId) -> Result<Duration> {
+    let mut res = libc::timespec {
+        tv_sec: 0,
+        tv_nsec: 0,
+    };
+
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "sgx")] {
+            extern "C" {
+                fn vdso_ocall_clock_getres(
+                    ret: *mut libc::c_int,
+                    clockid: libc::c_int,
+                    res: *mut libc::timespec,
+                ) -> sgx_types::sgx_status_t;
+            }
+            let mut ret: libc::c_int = 0;
+            unsafe {
+                vdso_ocall_clock_getres(&mut ret as *mut _, clockid as _, &mut res as *mut _);
+            }
+        } else {
+            let ret = unsafe { libc::clock_getres(clockid as _, &mut res as *mut _) };
+        }
+    }
+
+    if ret == 0 {
+        Ok(Duration::new(res.tv_sec as u64, res.tv_nsec as u32))
+    } else {
+        return_errno!(EINVAL, "clock_getres_slow failed")
+    }
+}
+
 // All unit tests
 #[cfg(test)]
+#[allow(deprecated)]
 mod tests {
     use super::*;
-    use std::{thread, time};
+    use std::thread;
 
     const LOOPS: usize = 3;
     const SLEEP_DURATION: u64 = 10;
-    const MAX_DIFF_NSEC: u64 = 10000;
-    const USEC_PER_SEC: u64 = 1000000;
+    const HRES_MAX_DIFF_NANOS: u64 = 50_000;
+    const COARSE_MAX_DIFF_NANOS: u64 = 4_000_000;
 
     #[test]
-    fn test_time() {
-        let vdso = Vdso::new().unwrap();
+    fn test_clock_gettime() {
+        test_single_clock_gettime(ClockId::CLOCK_REALTIME_COARSE, COARSE_MAX_DIFF_NANOS);
+        test_single_clock_gettime(ClockId::CLOCK_MONOTONIC_COARSE, COARSE_MAX_DIFF_NANOS);
+        test_single_clock_gettime(ClockId::CLOCK_REALTIME, HRES_MAX_DIFF_NANOS);
+        test_single_clock_gettime(ClockId::CLOCK_MONOTONIC, HRES_MAX_DIFF_NANOS);
+        test_single_clock_gettime(ClockId::CLOCK_BOOTTIME, HRES_MAX_DIFF_NANOS);
+        test_single_clock_gettime(ClockId::CLOCK_MONOTONIC_RAW, HRES_MAX_DIFF_NANOS);
+    }
+
+    fn test_single_clock_gettime(clockid: ClockId, max_diff_nanos: u64) {
         for _ in 0..LOOPS {
-            let mut vdso_tloc: time_t = 0;
-            let mut libc_tloc: time_t = 0;
-            let vdso_time = vdso.time(&mut vdso_tloc as *mut _).unwrap();
-            let libc_time = unsafe { libc::time(&mut libc_tloc as *mut _) };
-            println!(
-                "[time()] vdso: {}, libc: {}, diff: {}",
-                vdso_time,
-                libc_time,
-                libc_time - vdso_time
-            );
-            assert_eq!(vdso_time, libc_time);
-            assert_eq!(vdso_time, vdso_tloc);
-
-            let ten_millis = time::Duration::from_millis(SLEEP_DURATION);
-            thread::sleep(ten_millis);
-        }
-    }
-
-    #[test]
-    fn test_clock_gettime_realtime() {
-        test_single_clock_gettime(CLOCK_REALTIME);
-    }
-
-    #[test]
-    fn test_clock_gettime_realtime_coarse() {
-        test_single_clock_gettime(CLOCK_REALTIME_COARSE);
-    }
-
-    #[test]
-    fn test_clock_gettime_monotonic() {
-        test_single_clock_gettime(CLOCK_MONOTONIC);
-    }
-
-    #[test]
-    fn test_clock_gettime_monotonic_coarse() {
-        test_single_clock_gettime(CLOCK_MONOTONIC_COARSE);
-    }
-
-    #[test]
-    fn test_clock_gettime_monotonic_raw() {
-        test_single_clock_gettime(CLOCK_MONOTONIC_RAW);
-    }
-
-    #[test]
-    fn test_clock_gettime_boottime() {
-        test_single_clock_gettime(CLOCK_BOOTTIME);
-    }
-
-    fn test_single_clock_gettime(clockid: clockid_t) {
-        let vdso = Vdso::new().unwrap();
-        for _ in 0..LOOPS {
-            let mut vdso_tp = timespec {
+            let mut libc_tp = libc::timespec {
                 tv_sec: 0,
                 tv_nsec: 0,
             };
-            let mut libc_tp = timespec {
-                tv_sec: 0,
-                tv_nsec: 0,
-            };
-
-            vdso.clock_gettime(clockid, &mut vdso_tp).unwrap();
-
             unsafe { libc::clock_gettime(clockid as _, &mut libc_tp as *mut _) };
+            let libc_time = Duration::new(libc_tp.tv_sec as u64, libc_tp.tv_nsec as u32);
 
-            let diff = (libc_tp.tv_sec - vdso_tp.tv_sec) * NSEC_PER_SEC as i64
-                + (libc_tp.tv_nsec - vdso_tp.tv_nsec);
+            let vdso_time = clock_gettime(clockid).unwrap();
 
-            println!(
-                "[clock_gettime({:?})], vdso: [ tv_sec {}, tv_nsec {} ], libc: [ tv_sec {}, tv_nsec {} ], diff: {} nsec",
-                clockid, vdso_tp.tv_sec, vdso_tp.tv_nsec, libc_tp.tv_sec, libc_tp.tv_nsec, diff,
-            );
-            assert!(diff >= 0 && diff <= MAX_DIFF_NSEC as i64);
+            assert!(vdso_time - libc_time <= Duration::from_nanos(max_diff_nanos));
 
-            let ten_millis = time::Duration::from_millis(SLEEP_DURATION);
-            thread::sleep(ten_millis);
-        }
-    }
-
-    #[test]
-    fn test_gettimeofday() {
-        let vdso = Vdso::new().unwrap();
-        for _ in 0..LOOPS {
-            let mut vdso_tv = timeval {
-                tv_sec: 0,
-                tv_usec: 0,
-            };
-            let mut vdso_tz = timezone::default();
-            let mut libc_tv = timeval {
-                tv_sec: 0,
-                tv_usec: 0,
-            };
-            let mut libc_tz = timezone::default();
-
-            vdso.gettimeofday(&mut vdso_tv as *mut _, &mut vdso_tz as *mut _)
-                .unwrap();
-
-            unsafe {
-                libc::gettimeofday(
-                    &mut libc_tv as *mut _,
-                    &mut libc_tz as *mut timezone as *mut _,
-                )
-            };
-
-            let diff = (libc_tv.tv_sec - vdso_tv.tv_sec) * USEC_PER_SEC as i64
-                + (libc_tv.tv_usec - vdso_tv.tv_usec);
-
-            println!(
-                "[gettimeofday()], vdso: [ tv_sec {}, tv_usec {} ], libc: [ tv_sec {}, tv_usec {} ], diff: {} nsec",
-                vdso_tv.tv_sec, vdso_tv.tv_usec, libc_tv.tv_sec, libc_tv.tv_usec, diff,
-            );
-            assert!(diff >= 0 && diff <= (MAX_DIFF_NSEC / NSEC_PER_USEC) as i64);
-            assert_eq!(vdso_tz.tz_minuteswest, libc_tz.tz_minuteswest);
-            assert_eq!(vdso_tz.tz_dsttime, libc_tz.tz_dsttime);
-
-            let ten_millis = time::Duration::from_millis(SLEEP_DURATION);
-            thread::sleep(ten_millis);
+            thread::sleep(Duration::from_millis(SLEEP_DURATION));
         }
     }
 
     #[test]
     fn test_clock_getres() {
-        test_single_clock_getres(CLOCK_REALTIME_COARSE);
-        test_single_clock_getres(CLOCK_MONOTONIC_COARSE);
-        test_single_clock_getres(CLOCK_REALTIME);
-        test_single_clock_getres(CLOCK_MONOTONIC);
-        test_single_clock_getres(CLOCK_BOOTTIME);
-        test_single_clock_getres(CLOCK_MONOTONIC_RAW);
+        test_single_clock_getres(ClockId::CLOCK_REALTIME_COARSE);
+        test_single_clock_getres(ClockId::CLOCK_MONOTONIC_COARSE);
+        test_single_clock_getres(ClockId::CLOCK_REALTIME);
+        test_single_clock_getres(ClockId::CLOCK_MONOTONIC);
+        test_single_clock_getres(ClockId::CLOCK_BOOTTIME);
+        test_single_clock_getres(ClockId::CLOCK_MONOTONIC_RAW);
     }
 
-    fn test_single_clock_getres(clockid: clockid_t) {
-        let vdso = Vdso::new().unwrap();
+    fn test_single_clock_getres(clockid: ClockId) {
         for _ in 0..LOOPS {
-            let mut vdso_tp = timespec {
+            let mut libc_tp = libc::timespec {
                 tv_sec: 0,
                 tv_nsec: 0,
             };
-            let mut libc_tp = timespec {
-                tv_sec: 0,
-                tv_nsec: 0,
-            };
-
-            vdso.clock_getres(clockid, &mut vdso_tp).unwrap();
-
             unsafe { libc::clock_getres(clockid as _, &mut libc_tp as *mut _) };
 
-            println!(
-                "[clock_getres({:?})], vdso: [ tv_sec {}, tv_nsec {} ], libc: [ tv_sec {}, tv_nsec {} ]",
-                clockid, vdso_tp.tv_sec, vdso_tp.tv_nsec, libc_tp.tv_sec, libc_tp.tv_nsec,
-            );
-            assert_eq!(vdso_tp.tv_sec, libc_tp.tv_sec);
-            assert_eq!(vdso_tp.tv_nsec, libc_tp.tv_nsec);
+            let res = clock_getres(clockid).unwrap();
+
+            assert_eq!(res.as_secs(), libc_tp.tv_sec as u64);
+            assert_eq!(res.subsec_nanos(), libc_tp.tv_nsec as u32);
+        }
+    }
+
+    #[test]
+    fn test_monotonic() {
+        let mut last_now = Duration::new(0, 0);
+        for _ in 0..1_000_000 {
+            let now = clock_gettime(ClockId::CLOCK_MONOTONIC).unwrap();
+            assert!(now >= last_now);
+            last_now = now;
+        }
+    }
+
+    mod logger {
+        use log::{Level, LevelFilter, Metadata, Record};
+
+        #[ctor::ctor]
+        fn auto_init() {
+            log::set_logger(&LOGGER)
+                .map(|()| log::set_max_level(LevelFilter::Trace))
+                .expect("failed to init the logger");
+        }
+
+        static LOGGER: SimpleLogger = SimpleLogger;
+
+        struct SimpleLogger;
+
+        impl log::Log for SimpleLogger {
+            fn enabled(&self, metadata: &Metadata) -> bool {
+                metadata.level() <= Level::Trace
+            }
+
+            fn log(&self, record: &Record) {
+                if self.enabled(record.metadata()) {
+                    println!("[{}] {}", record.level(), record.args());
+                }
+            }
+
+            fn flush(&self) {}
         }
     }
 }

--- a/src/libos/src/entry/syscall.rs
+++ b/src/libos/src/entry/syscall.rs
@@ -147,6 +147,7 @@ macro_rules! process_syscall_table_with_callback {
 
             (Futex = 202) => do_futex(futex_addr: *const i32, futex_op: u32, futex_val: i32, timeout: u64, futex_new_addr: *const i32, bitset: u32),
             (SchedYield = 24) => do_sched_yield(),
+            (Nanosleep = 35) => do_nanosleep(req_u: *const timespec_t, rem_u: *mut timespec_t),
 
             (Gettimeofday = 96) => do_gettimeofday(tv_u: *mut timeval_t),
             (ClockGettime = 228) => do_clock_gettime(clockid: clockid_t, ts_u: *mut timespec_t),
@@ -840,7 +841,7 @@ async fn do_clock_getres(clockid: clockid_t, res_u: *mut timespec_t) -> Result<i
 }
 
 // TODO: handle remainder
-fn do_nanosleep(req_u: *const timespec_t, rem_u: *mut timespec_t) -> Result<isize> {
+async fn do_nanosleep(req_u: *const timespec_t, rem_u: *mut timespec_t) -> Result<isize> {
     let req = {
         check_ptr(req_u)?;
         timespec_t::from_raw_ptr(req_u)?
@@ -851,7 +852,7 @@ fn do_nanosleep(req_u: *const timespec_t, rem_u: *mut timespec_t) -> Result<isiz
     } else {
         None
     };
-    crate::time::do_nanosleep(&req, rem)?;
+    crate::time::do_nanosleep(&req, rem).await?;
     Ok(0)
 }
 

--- a/src/libos/src/process/do_futex.rs
+++ b/src/libos/src/process/do_futex.rs
@@ -7,7 +7,6 @@ use std::time::Duration;
 use async_rt::wait::{Waiter, Waker};
 
 use crate::prelude::*;
-use crate::time::{timespec_t, ClockID};
 
 /// `FutexOp`, `FutexFlags`, and `futex_op_and_flags_from_u32` are helper types and
 /// functions for handling the versatile commands and arguments of futex system

--- a/src/libos/src/process/do_wait4.rs
+++ b/src/libos/src/process/do_wait4.rs
@@ -38,7 +38,7 @@ pub async fn do_wait4(child_filter: &ProcessFilter) -> Result<(pid_t, i32)> {
             let exit_status = free_zombie_child(&process, process_inner, zombie_pid);
             return Ok((zombie_pid, exit_status));
         }
-    });
+    })
 }
 
 fn free_zombie_child(

--- a/src/libos/src/process/syscalls.rs
+++ b/src/libos/src/process/syscalls.rs
@@ -8,7 +8,7 @@ use super::do_spawn::FileAction;
 use super::prctl::PrctlCmd;
 use super::process::ProcessFilter;
 use crate::prelude::*;
-use crate::time::{timespec_t, ClockID};
+use crate::time::{timespec_t, ClockId};
 use crate::util::mem_util::from_user::*;
 
 pub async fn do_spawn_for_musl(
@@ -281,9 +281,9 @@ pub async fn do_futex(
         if is_absolute {
             // TODO: use a secure clock to transfer the real time to monotonic time
             let clock_id = if futex_flags.contains(FutexFlags::FUTEX_CLOCK_REALTIME) {
-                ClockID::CLOCK_REALTIME
+                ClockId::CLOCK_REALTIME
             } else {
-                ClockID::CLOCK_MONOTONIC
+                ClockId::CLOCK_MONOTONIC
             };
             let now = crate::time::do_clock_gettime(clock_id)
                 .unwrap()

--- a/src/libos/src/signal/do_sigtimedwait.rs
+++ b/src/libos/src/signal/do_sigtimedwait.rs
@@ -32,7 +32,7 @@ pub async fn do_sigtimedwait(interest: SigSet, timeout: Option<&Duration>) -> Re
             let siginfo = signal.to_info();
             return Ok(siginfo);
         }
-    });
+    })
 }
 
 fn dequeue_pending_signal(

--- a/src/libos/src/time/up_time.rs
+++ b/src/libos/src/time/up_time.rs
@@ -1,8 +1,8 @@
-use super::{do_clock_gettime, ClockID};
+use super::{do_clock_gettime, ClockId};
 use std::time::Duration;
 
 lazy_static! {
-    static ref BOOT_TIME_STAMP: Duration = do_clock_gettime(ClockID::CLOCK_MONOTONIC_RAW)
+    static ref BOOT_TIME_STAMP: Duration = do_clock_gettime(ClockId::CLOCK_MONOTONIC_RAW)
         .unwrap()
         .as_duration();
 }
@@ -12,7 +12,7 @@ pub fn init() {
 }
 
 pub fn get() -> Option<Duration> {
-    do_clock_gettime(ClockID::CLOCK_MONOTONIC_RAW)
+    do_clock_gettime(ClockId::CLOCK_MONOTONIC_RAW)
         .unwrap()
         .as_duration()
         .checked_sub(*BOOT_TIME_STAMP)

--- a/src/pal/src/ocalls/time.c
+++ b/src/pal/src/ocalls/time.c
@@ -3,17 +3,6 @@
 #include <sys/prctl.h>
 #include "ocalls.h"
 
-void occlum_ocall_gettimeofday(struct timeval *tv) {
-    gettimeofday(tv, NULL);
-}
-
-void occlum_ocall_clock_gettime(int clockid, struct timespec *tp) {
-    clock_gettime(clockid, tp);
-}
-
-void occlum_ocall_clock_getres(int clockid, struct timespec *res) {
-    clock_getres(clockid, res);
-}
 
 int occlum_ocall_nanosleep(const struct timespec *req, struct timespec *rem) {
     return nanosleep(req, rem);

--- a/src/pal/src/ocalls/time.c
+++ b/src/pal/src/ocalls/time.c
@@ -4,10 +4,6 @@
 #include "ocalls.h"
 
 
-int occlum_ocall_nanosleep(const struct timespec *req, struct timespec *rem) {
-    return nanosleep(req, rem);
-}
-
 int occlum_ocall_thread_getcpuclock(struct timespec *tp) {
     clockid_t thread_clock_id;
     int ret = pthread_getcpuclockid(pthread_self(), &thread_clock_id);

--- a/test/Makefile
+++ b/test/Makefile
@@ -21,7 +21,7 @@ TEST_DEPS := client data_sink
 # 	ioctl fcntl eventfd emulate_syscall access signal sysinfo prctl rename procfs
 TESTS ?= access chmod chown cpuid empty emulate_syscall eventfd exit_group file \
 	getpid hello_world link malloc mkdir mmap pthread rdtsc rename rlimit signal \
-	spawn stat symlink time tls truncate
+	sleep spawn stat symlink time tls truncate
 # Benchmarks: need to be compiled and run by bench-% target
 BENCHES := spawn_and_exit_latency pipe_throughput unix_socket_throughput
 


### PR DESCRIPTION
#29 [RFC] Timeout support

- [async-rt]
    - Add timeout feature to the async-rt.
- [ngo]
    - Add rust-hash-wheel-timer submodule. Port rust-hash-wheel-timer crate to rust-sgx-sdk. (https://github.com/ShuochengWang/rust-hash-wheel-timer). 
- [libos]
    - Support timeout in do_futex / do_sigtimedwait
    - Support nanosleep