### PR TITLE
fix system hang issue

### DIFF
--- a/src/libos/crates/async-rt/src/wait/macros.rs
+++ b/src/libos/crates/async-rt/src/wait/macros.rs
@@ -114,12 +114,15 @@ macro_rules! waiter_loop {
                         // Wait until being woken by the waiter queue or reach timeout
                         let timeout: &mut core::time::Duration = (*timeout).borrow_mut();
                         if let Err(e) = waiter.wait_timeout(Some(timeout)).await {
-                            // The timeout expired, exit loop.
+                            // The timeout expired or interrupted, exit loop.
                             break Err(e);
                         }
                     } else {
                         // Wait until being woken by the waiter queue
-                        waiter.wait().await;
+                        if let Err(e) = waiter.wait().await {
+                            // Interrupted, exit loop.
+                            break Err(e);
+                        }
                     }
                     // Prepare the waiter so that we can try the loop body again
                     waiter.reset();

--- a/src/libos/crates/async-rt/src/wait/mod.rs
+++ b/src/libos/crates/async-rt/src/wait/mod.rs
@@ -1,8 +1,10 @@
 mod macros;
+mod signal;
 mod waiter;
 mod waiter_queue;
 
 pub use self::macros::AutoWaiter;
+pub use self::signal::Signal;
 pub use self::waiter::{Waiter, Waker};
 pub use self::waiter_queue::WaiterQueue;
 

--- a/src/libos/crates/async-rt/src/wait/signal.rs
+++ b/src/libos/crates/async-rt/src/wait/signal.rs
@@ -1,0 +1,53 @@
+use crate::prelude::*;
+use crate::wait::{Waiter, WaiterQueue};
+
+pub struct Signal {
+    count: Mutex<i32>,
+    waiter_queue: WaiterQueue,
+}
+
+impl Signal {
+    pub fn new() -> Self {
+        Self {
+            count: Mutex::new(0),
+            waiter_queue: WaiterQueue::new(),
+        }
+    }
+    pub fn produce(&self) {
+        let mut count = self.count.lock();
+        *count += 1;
+        self.waiter_queue.wake_all();
+    }
+
+    pub fn empty(&self) -> bool {
+        let mut count = self.count.lock();
+        *count == 0
+    }
+
+    pub fn consume(&self) {
+        let mut count = self.count.lock();
+        *count -= 1;
+
+        if *count < 0 {
+            panic!("signal number is incorrect");
+        }
+    }
+
+    pub fn waiter(&self) -> Option<Arc<Waiter>> {
+        let mut waiter = Waiter::new();
+
+        let count = self.count.lock();
+        if *count == 0 {
+            self.waiter_queue.enqueue(&mut waiter);
+            Some(Arc::new(waiter))
+        } else {
+            None
+        }
+    }
+
+    pub fn unregister(&self, waiter: &mut Arc<Waiter>) {
+        let count = self.count.lock();
+        let mut waiter = Arc::<Waiter>::get_mut(waiter).unwrap();
+        self.waiter_queue.dequeue(&mut waiter);
+    }
+}

--- a/src/libos/src/process/do_clone.rs
+++ b/src/libos/src/process/do_clone.rs
@@ -88,10 +88,12 @@ pub async fn do_clone(
         }
     }
 
-    async_rt::task::spawn(crate::entry::thread::main_loop(
-        new_thread_ref,
-        init_cpu_state,
-    ));
+    let signal = current!().process().count().clone();
+
+    async_rt::task::spawn(
+        crate::entry::thread::main_loop(new_thread_ref, init_cpu_state),
+        Some(signal),
+    );
     Ok(new_tid)
 }
 

--- a/src/libos/src/process/do_spawn/mod.rs
+++ b/src/libos/src/process/do_spawn/mod.rs
@@ -95,10 +95,13 @@ fn do_spawn_common(
     let new_main_thread = new_process_ref
         .main_thread()
         .expect("the main thread is just created; it must exist");
-    async_rt::task::spawn(crate::entry::thread::main_loop(
-        new_main_thread,
-        init_cpu_state,
-    ));
+
+    let signal = new_process_ref.count().clone();
+
+    async_rt::task::spawn(
+        crate::entry::thread::main_loop(new_main_thread, init_cpu_state),
+        Some(signal),
+    );
 
     let new_pid = new_process_ref.pid();
     Ok(new_pid)

--- a/test/exit_group/main.c
+++ b/test/exit_group/main.c
@@ -53,16 +53,16 @@ int test_exit_group_to_force_threads_terminate(void) {
     }
 
     // TODO: Enable below two test cases when wait_timeout support interrupts
-    // pthread_t sleeping_thread;
-    // if (pthread_create(&sleeping_thread, NULL, sleeping_thread_func, NULL) < 0) {
-    //     printf("ERROR: pthread_create failed\n");
-    //     return -1;
-    // }
-    // pthread_t futex_wait_thread;
-    // if (pthread_create(&futex_wait_thread, NULL, futex_wait_thread_func, NULL) < 0) {
-    //     printf("ERROR: pthread_create failed\n");
-    //     return -1;
-    // }
+    pthread_t sleeping_thread;
+    if (pthread_create(&sleeping_thread, NULL, sleeping_thread_func, NULL) < 0) {
+        printf("ERROR: pthread_create failed\n");
+        return -1;
+    }
+    pthread_t futex_wait_thread;
+    if (pthread_create(&futex_wait_thread, NULL, futex_wait_thread_func, NULL) < 0) {
+        printf("ERROR: pthread_create failed\n");
+        return -1;
+    }
 
     // Sleep for a while to make sure all three threads are running
     useconds_t half_second = 500 * 1000; // in us


### PR DESCRIPTION
1. Support interruptible timer
    + in some case (nano_sleep, futex, ....), the waiter is not able to be interrupted to handle signal 
2. Support async wake
    + if the two threads sync with futex are scheduled on same vcpu, the system would hang 