### PR TITLE
[libos] enable futex async wake

### DIFF
--- a/src/libos/src/process/do_exit.rs
+++ b/src/libos/src/process/do_exit.rs
@@ -1,7 +1,7 @@
 use std::intrinsics::atomic_store;
 use std::sync::Weak;
 
-use super::do_futex::futex_wake;
+use super::do_futex::futex_wake_sync;
 use super::process::{Process, ProcessFilter};
 use super::{table, ProcessRef, TermStatus, ThreadRef, ThreadStatus};
 use crate::prelude::*;
@@ -42,7 +42,8 @@ fn exit_thread(term_status: TermStatus) {
         unsafe {
             atomic_store(ctid_ptr.as_ptr(), 0);
         }
-        futex_wake(ctid_ptr.as_ptr() as *const i32, 1);
+
+        futex_wake_sync(ctid_ptr.as_ptr() as *const i32, 1);
     }
 
     // Notify waiters that the owner of robust futex has died.

--- a/src/libos/src/process/do_robust_list.rs
+++ b/src/libos/src/process/do_robust_list.rs
@@ -187,7 +187,7 @@ pub fn wake_robust_futex(futex_addr: *const i32, tid: pid_t) -> Result<()> {
         // Wakeup one waiter
         if futex_val.load(Ordering::SeqCst) & FUTEX_WAITERS != 0 {
             debug!("wake robust futex addr: {:?}", futex_addr);
-            super::do_futex::futex_wake(futex_addr, 1)?;
+            super::do_futex::futex_wake_sync(futex_addr, 1)?;
         }
         break;
     }

--- a/src/libos/src/process/syscalls.rs
+++ b/src/libos/src/process/syscalls.rs
@@ -326,11 +326,14 @@ pub async fn do_futex(
         }
         FutexOp::FUTEX_WAKE => {
             let max_count = get_futex_val(futex_val)?;
-            super::do_futex::futex_wake(futex_addr, max_count).map(|count| count as isize)
+            super::do_futex::futex_wake(futex_addr, max_count)
+                .await
+                .map(|count| count as isize)
         }
         FutexOp::FUTEX_WAKE_BITSET => {
             let max_count = get_futex_val(futex_val)?;
             super::do_futex::futex_wake_bitset(futex_addr, max_count, bitset)
+                .await
                 .map(|count| count as isize)
         }
         FutexOp::FUTEX_REQUEUE => {
@@ -338,6 +341,7 @@ pub async fn do_futex(
             let max_nwakes = get_futex_val(futex_val)?;
             let max_nrequeues = get_futex_val(timeout as i32)?;
             super::do_futex::futex_requeue(futex_addr, max_nwakes, max_nrequeues, futex_new_addr)
+                .await
                 .map(|nwakes| nwakes as isize)
         }
         _ => return_errno!(ENOSYS, "the futex operation is not supported"),


### PR DESCRIPTION
If there is only one vcpu, the wake thread need a way to execute the waiting thread.