### PR TITLE
Temporary disable interrupt thread

### DIFF
--- a/.github/workflows/demo_test.yml
+++ b/.github/workflows/demo_test.yml
@@ -271,8 +271,18 @@ jobs:
       run: docker exec pytorch_test bash -c "cd /root/occlum/demos/pytorch; ./install_python_with_conda.sh"
 
     - name: Run pytorch test
-      run: docker exec pytorch_test bash -c "cd /root/occlum/demos/pytorch; SGX_MODE=SIM ./run_pytorch_on_occlum.sh"
+      run: docker exec -d pytorch_test bash -c "cd /root/occlum/demos/pytorch; SGX_MODE=SIM ./run_pytorch_on_occlum.sh 2>&1 | tee /root/occlum/log"
 
+    # FIXME: PyTorch can't exit with interrupt support
+    - name: Kill the container
+      run: |
+        sleep 360;
+        cat "$GITHUB_WORKSPACE/log";
+        if grep -q Done "$GITHUB_WORKSPACE/log"; then
+          docker stop pytorch_test
+        else
+          exit 1
+        fi
 
   Tensorflow_test:
     runs-on: ubuntu-20.04
@@ -508,7 +518,7 @@ jobs:
 
     - name: Run the Vault client
       run: |
-        sleep ${{ env.nap_time }};
+        sleep 360;
         docker exec vault_test bash -c "cd /root/occlum/demos/golang/vault && ./run_occlum_vault_test.sh"
 
     - name: Check Vault log

--- a/src/pal/src/pal_interrupt_thread.c
+++ b/src/pal/src/pal_interrupt_thread.c
@@ -49,15 +49,16 @@ int pal_interrupt_thread_start(void) {
     is_running = 1;
     pal_thread_counter_inc();
 
-    int ret = 0;
-    if ((ret = pthread_create(&thread, NULL, thread_func, NULL))) {
-        is_running = 0;
-        pal_thread_counter_dec();
+    // FIXME: temporary disable interrupt thread
+    // int ret = 0;
+    // if ((ret = pthread_create(&thread, NULL, thread_func, NULL))) {
+    //     is_running = 0;
+    //     pal_thread_counter_dec();
 
-        errno = ret;
-        PAL_ERROR("Failed to start the interrupt thread: %s", errno2str(errno));
-        return -1;
-    }
+    //     errno = ret;
+    //     PAL_ERROR("Failed to start the interrupt thread: %s", errno2str(errno));
+    //     return -1;
+    // }
     return 0;
 }
 
@@ -70,12 +71,13 @@ int pal_interrupt_thread_stop(void) {
     is_running = 0;
     pal_thread_counter_dec();
 
-    int ret = 0;
-    if ((ret = pthread_join(thread, NULL))) {
-        errno = ret;
-        PAL_ERROR("Failed to free the interrupt thread: %s", errno2str(errno));
-        return -1;
-    }
+    // FIXME: temporary disable interrupt thread
+    // int ret = 0;
+    // if ((ret = pthread_join(thread, NULL))) {
+    //     errno = ret;
+    //     PAL_ERROR("Failed to free the interrupt thread: %s", errno2str(errno));
+    //     return -1;
+    // }
 
     return 0;
 }

--- a/test/exit_group/main.c
+++ b/test/exit_group/main.c
@@ -38,12 +38,13 @@ static void *futex_wait_thread_func(void *_) {
 
 // exit_group syscall should terminate all threads in a thread group.
 int test_exit_group_to_force_threads_terminate(void) {
+    // TODO: Enable this test case when fixed the interrupt thread bug
     // Create three types of threads that will not exit voluntarily
-    pthread_t busyloop_thread;
-    if (pthread_create(&busyloop_thread, NULL, busyloop_thread_func, NULL) < 0) {
-        printf("ERROR: pthread_create failed\n");
-        return -1;
-    }
+    // pthread_t busyloop_thread;
+    // if (pthread_create(&busyloop_thread, NULL, busyloop_thread_func, NULL) < 0) {
+    //     printf("ERROR: pthread_create failed\n");
+    //     return -1;
+    // }
     pthread_t sleeping_thread;
     if (pthread_create(&sleeping_thread, NULL, sleeping_thread_func, NULL) < 0) {
         printf("ERROR: pthread_create failed\n");

--- a/test/pthread/main.c
+++ b/test/pthread/main.c
@@ -267,7 +267,8 @@ static int test_mutex_timedlock() {
 static test_case_t test_cases[] = {
     TEST_CASE(test_mutex_with_concurrent_counter),
     TEST_CASE(test_robust_mutex_with_concurrent_counter),
-    TEST_CASE(test_mutex_with_cond_wait),
+    // TODO: Enable this case when the interrupt bug fixed
+    // TEST_CASE(test_mutex_with_cond_wait),
     TEST_CASE(test_mutex_timedlock),
 };
 


### PR DESCRIPTION
The NGO interrupt implementation depends on SIG64 signal. There is an unknown bug which make the demos randomly failed.
So temporary disable this feature to enable other development tasks. 