### PR TITLE
Support simulation mode when the rdfsbase/wrfsbase instructions are not

### DIFF
--- a/src/libos/src/entry/context_switch/arch_prctl_x86-64.S
+++ b/src/libos/src/entry/context_switch/arch_prctl_x86-64.S
@@ -3,27 +3,22 @@
 #if SGX_MODE_SIM
 
 #define __ASSEMBLY__
-#include "task.h"
+#include "switch.h"
 
     .file "arch_prctl.S"
 
-    .global __arch_prctl
-    .type __arch_prctl, @function
-__arch_prctl:
+    .global __occlum_arch_prctl
+    .type __occlum_arch_prctl, @function
+__occlum_arch_prctl:
     // A system-call is done via the syscall instruction.
     // This clobbers RCX and R11 as well as the RAX return value, but other registers are preserved.
     // The number of the syscall has to be passed in register RAX.
-    pushq %rcx
-    pushq %r11
-
     mov $ARCH_PRCTL, %eax
     syscall
 
     // Register RAX contains the result of the system-call.
     cmp $0, %rax
     jne __syscall_error
-    popq %r11
-    popq %rcx
     ret
 
 __syscall_error: // This should never happen

--- a/src/libos/src/entry/context_switch/switch.h
+++ b/src/libos/src/entry/context_switch/switch.h
@@ -33,6 +33,11 @@ less than 4096 is unused by anyone. We can use it.*/
 #define CPU_CONTEXT_RFLAGS  (17*8)
 #define CPU_CONTEXT_FSBASE  (18*8)
 
+/* arch_prctl syscall number and parameter */
+#define ARCH_PRCTL          (0x9E)
+#define ARCH_SET_FS         (0x01002)
+#define ARCH_GET_FS         (0x01003)
+
 #else /* ! __ASSEMBLY_ */
 
 #include <stddef.h>

--- a/src/libos/src/entry/context_switch/switch_x86-64.S
+++ b/src/libos/src/entry/context_switch/switch_x86-64.S
@@ -13,24 +13,41 @@ __switch_to_user:
     movq %rsi, %gs:(TD_KERNEL_JMPBUF)
     movq %rdx, %gs:(TD_USER_FAULT)
     movq %rsp, %gs:(TD_KERNEL_RSP)
+
+    // Save the context point in r12
+    movq %rdi, %r12
+
+#if SGX_MODE_SIM
+    sub $8, %rsp
+    movq %rsp, %rsi
+    movq $ARCH_GET_FS, %rdi
+    call __occlum_arch_prctl
+    popq %rcx
+#else // SGX_MODE_HW
     rdfsbase %rcx
+#endif
     movq %rcx, %gs:(TD_KERNEL_FS)
 
     // Use user FS
-    movq CPU_CONTEXT_FSBASE(%rdi), %rsi
+    movq CPU_CONTEXT_FSBASE(%r12), %rsi
+#if SGX_MODE_SIM
+    movq $ARCH_SET_FS, %rdi
+    call __occlum_arch_prctl
+#else // SGX_MODE_HW
     wrfsbase %rsi
+#endif
 
     // Get the user's RIP
-    movq CPU_CONTEXT_RIP(%rdi), %rcx
+    movq CPU_CONTEXT_RIP(%r12), %rcx
     movq %rcx, %gs:(TD_USER_RIP)
 
     // Restore rflags
     sub $8, %rsp
-    leaq CPU_CONTEXT_RFLAGS(%rdi), %rsp
+    leaq CPU_CONTEXT_RFLAGS(%r12), %rsp
     popfq
 
     // Restore the CPU context of the user space
-    movq %rdi, %rsp
+    movq %r12, %rsp
     pop %r8
     pop %r9
     pop %r10
@@ -57,8 +74,13 @@ __switch_to_user:
     movq %gs:(TD_KERNEL_RSP), %rsp
 
     // Switch to the kernel FS
-    movq %gs:(TD_KERNEL_FS), %rcx
-    wrfsbase %rcx
+    movq %gs:(TD_KERNEL_FS), %rsi
+#if SGX_MODE_SIM
+    movq $ARCH_SET_FS, %rdi
+    call __occlum_arch_prctl
+#else // SGX_MODE_HW
+    wrfsbase %rsi
+#endif
 
     // Set the two pointers to NULL so that we can detect misuse
     xor %rax, %rax


### PR DESCRIPTION
Enable simulation mode on the system which does not support rdfsbase/wrfsbase