### PR TITLE
Improve the performance of disks

### DIFF
--- a/src/libos/Cargo.toml
+++ b/src/libos/Cargo.toml
@@ -8,7 +8,7 @@ name = "occlum_libos_core_rs"
 crate-type = ["staticlib"]
 
 [dependencies]
-async-rt  = { path = "crates/async-rt", default-features = false, features = ["sgx"] }
+async-rt  = { path = "crates/async-rt", default-features = false, features = ["sgx", "park"] }
 async-io  = { path = "crates/async-io", features = ["sgx"] }
 atomic = "0.5"
 bitflags = "1.0"

--- a/src/libos/crates/async-rt/Cargo.toml
+++ b/src/libos/crates/async-rt/Cargo.toml
@@ -7,10 +7,15 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["vdso-time/std", "use_latency", "libc"]
+default = ["std", "park"] 
+std = ["vdso-time/std", "use_latency", "libc"]
 auto_run = ["env_logger"]
 use_latency = []
 sgx = ["sgx_tstd", "flume/sgx", "vdso-time/sgx", "hierarchical_hash_wheel_timer/sgx", "sgx_types", "sgx_libc", "sgx-untrusted-alloc"]
+# This feature parks idle threads of the executor so that they won't waste CPU time.
+# TODO: make this feature more efficient. Performace results (e.g., fio) indicate 
+# the current implemetation is suboptimal.
+park = []
 
 [dependencies]
 cfg-if = "1.0"
@@ -36,3 +41,4 @@ sgx_libc = { path = "../../../../deps/rust-sgx-sdk/sgx_libc", optional = true }
 
 [dev-dependencies]
 ctor = "0.1"
+env_logger = "0.8.4"

--- a/src/libos/crates/async-rt/src/parks/mod.rs
+++ b/src/libos/crates/async-rt/src/parks/mod.rs
@@ -28,6 +28,13 @@ impl Parks {
         sleep_thread.take();
     }
 
+    pub fn len(&self) -> usize {
+        self.sleep_threads.len()
+    }
+}
+
+#[cfg(feature = "park")]
+impl Parks {
     pub fn park(&self) {
         std::thread::park();
     }
@@ -52,8 +59,12 @@ impl Parks {
             self.unpark(thread_id);
         }
     }
+}
 
-    pub fn len(&self) -> usize {
-        self.sleep_threads.len()
-    }
+#[cfg(not(feature = "park"))]
+impl Parks {
+    pub fn park(&self) {}
+    pub fn park_timeout(&self, _duration: core::time::Duration) {}
+    pub fn unpark(&self, _thread_id: usize) {}
+    pub fn unpark_all(&self) {}
 }

--- a/src/libos/crates/block-device/src/block_buf.rs
+++ b/src/libos/crates/block-device/src/block_buf.rs
@@ -5,6 +5,7 @@ use crate::prelude::*;
 /// A buffer for block requests.
 ///
 /// The size of `BlockBuf` is a multiple of block size.
+#[derive(Debug)]
 pub struct BlockBuf {
     ptr: NonNull<u8>,
     len: usize,

--- a/src/libos/crates/block-device/src/block_device.rs
+++ b/src/libos/crates/block-device/src/block_device.rs
@@ -3,7 +3,7 @@ use core::any::Any;
 use crate::prelude::*;
 
 /// A block device.
-pub trait BlockDevice: Any + Send + Sync {
+pub trait BlockDevice: Any + Send + Sync + Debug {
     /// Return the total number of blocks in the device.
     fn total_blocks(&self) -> usize;
 

--- a/src/libos/crates/block-device/src/block_device_ext.rs
+++ b/src/libos/crates/block-device/src/block_device_ext.rs
@@ -67,13 +67,20 @@ impl<'a> Impl<'a> {
     }
 
     pub async fn read(&self, offset: usize, read_buf: &mut [u8]) -> Result<usize> {
+        let total_bytes = self.disk.total_blocks() * BLOCK_SIZE;
+
         if offset > isize::MAX as usize {
             return Err(errno!(EINVAL, "offset too large"));
+        }
+        if offset >= total_bytes {
+            return Ok(0);
+        }
+        if read_buf.len() == 0 {
+            return Ok(0);
         }
 
         // Block devices do not support "short reads". So we need to make sure
         // that all requested bytes are within the capability of the block device.
-        let total_bytes = self.disk.total_blocks() * BLOCK_SIZE;
         let read_buf = if offset + read_buf.len() <= total_bytes {
             read_buf
         } else {
@@ -170,6 +177,7 @@ impl<'a> Impl<'a> {
                     // Safety. The pointer of a slice must not be null.
                     let ptr = NonNull::new_unchecked(whole_block_buf.as_mut_ptr());
                     let len = whole_block_buf.len();
+                    debug_assert!(len % BLOCK_SIZE == 0);
                     // Safety. The memory refered to by the pair of pointer and
                     // length is valid during the entire life cyle of the request.
                     BlockBuf::from_raw_parts(ptr, len)
@@ -251,23 +259,25 @@ impl<'a> Impl<'a> {
     }
 
     pub async fn write(&self, offset: usize, write_buf: &[u8]) -> Result<usize> {
+        let total_bytes = self.disk.total_blocks() * BLOCK_SIZE;
+
         if offset > isize::MAX as usize {
             return Err(errno!(EINVAL, "offset too large"));
+        }
+        if offset >= total_bytes {
+            return Ok(0);
+        }
+        if write_buf.len() == 0 {
+            return Ok(0);
         }
 
         // Block devices do not support "short writes". So we need to make sure
         // that all requested bytes are within the capability of the block device.
-        let total_bytes = self.disk.total_blocks() * BLOCK_SIZE;
         let write_buf = if offset + write_buf.len() <= total_bytes {
             write_buf
         } else {
             &write_buf[..total_bytes - offset]
         };
-
-        let write_buf_len = write_buf.len();
-        if write_buf_len == 0 {
-            return Ok(0);
-        }
 
         if Self::cover_one_partial_block(offset, write_buf.len()) {
             self.do_write_one_partial_block(offset, write_buf).await
@@ -365,6 +375,7 @@ impl<'a> Impl<'a> {
                     // Safety. The pointer of a slice must not be null.
                     let ptr = NonNull::new_unchecked(whole_block_buf.as_ptr() as _);
                     let len = whole_block_buf.len();
+                    debug_assert!(len % BLOCK_SIZE == 0);
                     // Safety. The memory refered to by the pair of pointer and
                     // length is valid during the entire life cyle of the request.
                     BlockBuf::from_raw_parts(ptr, len)
@@ -465,7 +476,7 @@ impl<'a> Impl<'a> {
     }
 
     // Check if a read or writer covers only one partial block. In other words,
-    // it cannot cover more than one partial blocks or cover a whole block.
+    // it cannot cover more than one partial blocks or cover at least one whole block.
     fn cover_one_partial_block(offset: usize, len: usize) -> bool {
         if len >= BLOCK_SIZE {
             return false;

--- a/src/libos/crates/block-device/src/mem_disk.rs
+++ b/src/libos/crates/block-device/src/mem_disk.rs
@@ -1,4 +1,5 @@
 use crate::prelude::*;
+use core::fmt;
 
 /// An in-memory disk.
 pub struct MemDisk {
@@ -97,6 +98,14 @@ impl BlockDevice for MemDisk {
         }
 
         submission
+    }
+}
+
+impl fmt::Debug for MemDisk {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("MemDisk")
+            .field("total_blocks", &self.total_blocks)
+            .finish()
     }
 }
 

--- a/src/libos/crates/block-device/src/prelude.rs
+++ b/src/libos/crates/block-device/src/prelude.rs
@@ -1,6 +1,7 @@
 pub(crate) use alloc::boxed::Box;
 pub(crate) use alloc::sync::Arc;
 pub(crate) use alloc::vec::Vec;
+pub(crate) use core::fmt::Debug;
 pub(crate) use core::task::{Context, Poll};
 pub(crate) use errno::prelude::{Errno::*, Result, *};
 pub(crate) use spin::mutex::{Mutex, MutexGuard};

--- a/src/libos/crates/sgx-disk/src/crypt_disk.rs
+++ b/src/libos/crates/sgx-disk/src/crypt_disk.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use block_device::{BioReq, BioReqBuilder, BioResp, BioSubmission, BioType, BlockBuf, BlockDevice};
 #[cfg(feature = "sgx")]
 use sgx_tcrypto::{rsgx_rijndael128GCM_decrypt, rsgx_rijndael128GCM_encrypt};
@@ -148,6 +150,14 @@ impl BlockDevice for CryptDisk {
         } else {
             self.do_flush(req)
         }
+    }
+}
+
+impl fmt::Debug for CryptDisk {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CryptDisk")
+            .field("inner", &self.inner)
+            .finish()
     }
 }
 

--- a/src/libos/crates/sgx-disk/src/host_disk/io_uring_disk.rs
+++ b/src/libos/crates/sgx-disk/src/host_disk/io_uring_disk.rs
@@ -2,6 +2,7 @@ use block_device::{BioReq, BioSubmission, BioType, BlockDevice};
 use fs::File;
 use io_uring_callback::{Fd, IoHandle, IoUring};
 use new_self_ref_arc::new_self_ref_arc;
+use std::fmt;
 use std::io::prelude::*;
 use std::marker::PhantomData;
 use std::os::unix::io::{AsRawFd, RawFd};
@@ -368,6 +369,16 @@ impl<P: IoUringProvider> HostDisk for IoUringDisk<P> {
 
     fn path(&self) -> &Path {
         self.0.path.as_path()
+    }
+}
+
+impl<P: IoUringProvider> fmt::Debug for IoUringDisk<P> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let inner = &self.0;
+        f.debug_struct("IoUringDisk")
+            .field("path", &inner.path)
+            .field("total_blocks", &inner.total_blocks)
+            .finish()
     }
 }
 

--- a/src/libos/crates/sgx-disk/src/host_disk/io_uring_disk.rs
+++ b/src/libos/crates/sgx-disk/src/host_disk/io_uring_disk.rs
@@ -451,7 +451,11 @@ mod test {
                     let ring = ring.clone();
                     async move {
                         loop {
-                            ring.poll_completions();
+                            let mut remain_tries = 100;
+                            while remain_tries > 0 && ring.poll_completions() == 0 {
+                                remain_tries -= 1;
+                            }
+
                             async_rt::sched::yield_().await;
                         }
                     }

--- a/src/libos/crates/sgx-disk/src/host_disk/sync_io_disk.rs
+++ b/src/libos/crates/sgx-disk/src/host_disk/sync_io_disk.rs
@@ -1,5 +1,6 @@
 use block_device::{BioReq, BioSubmission, BioType, BlockDevice};
 use fs::File;
+use std::fmt;
 use std::io::prelude::*;
 use std::io::{IoSlice, IoSliceMut, SeekFrom};
 use std::path::{Path, PathBuf};
@@ -18,7 +19,6 @@ use crate::HostDisk;
 /// system calls from the enclave triggers enclave switching, which is costly.
 ///
 /// It is recommended to use `IoUringDisk` for an optimal performance.
-#[derive(Debug)]
 pub struct SyncIoDisk {
     file: Mutex<File>,
     path: PathBuf,
@@ -155,6 +155,15 @@ impl HostDisk for SyncIoDisk {
 
     fn path(&self) -> &Path {
         self.path.as_path()
+    }
+}
+
+impl fmt::Debug for SyncIoDisk {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SyncIoDisk")
+            .field("path", &self.path)
+            .field("total_blocks", &self.total_blocks)
+            .finish()
     }
 }
 

--- a/src/libos/crates/sgx-disk/src/pfs_disk/mod.rs
+++ b/src/libos/crates/sgx-disk/src/pfs_disk/mod.rs
@@ -1,8 +1,10 @@
-use block_device::{BioReq, BioSubmission, BioType, BlockDevice};
+use std::fmt;
 use std::io::prelude::*;
 use std::io::SeekFrom;
 use std::path::{Path, PathBuf};
 use std::sgxfs::SgxFile as PfsFile;
+
+use block_device::{BioReq, BioSubmission, BioType, BlockDevice};
 
 pub use self::open_options::OpenOptions;
 use crate::prelude::*;
@@ -157,5 +159,14 @@ impl Drop for PfsDisk {
         file.flush().unwrap();
         // TODO: sync
         // file.sync_all()?;
+    }
+}
+
+impl fmt::Debug for PfsDisk {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PfsDisk")
+            .field("path", &self.path)
+            .field("total_blocks", &self.total_blocks)
+            .finish()
     }
 }

--- a/src/libos/crates/vdso-time/src/lib.rs
+++ b/src/libos/crates/vdso-time/src/lib.rs
@@ -1,3 +1,20 @@
+//! Make Linux's VDSO time accessible from enclaves.
+//!
+//! # Maintainability
+//!
+//! This crate needs to know the memory layout of the VDSO time in the Linux
+//! kernel on the host.  Since we cannot trust any inputs from the host Linux,
+//! we embed the memory layout information of all recent versions of Linux
+//! kernels in the crate itself. Currently, the latest support kernel version
+//! is 5.16.
+//!
+//! To support future Linux kernels, this crate needs to be updated.
+//! The definition of the VDSO time data structures (`struct vdso_data`) can be found in
+//! [this file](https://github.com/torvalds/linux/blame/master/include/vdso/datapage.h).
+//! Check the file to see if a new kernel version changes the data structure.
+//! Most likely, it won't get affected. And we can simply add the new version to
+//! our list of supported versions.
+
 #![cfg_attr(feature = "sgx", no_std)]
 
 #[cfg(feature = "sgx")]
@@ -181,7 +198,7 @@ impl Vdso {
             (5, 0..=2) => VdsoDataPtr::V5_0(vdso_data_v5_0::vdsodata_ptr(vdso_addr)),
             (5, 3..=5) => VdsoDataPtr::V5_3(vdso_data_v5_3::vdsodata_ptr(vdso_addr)),
             (5, 6..=8) => VdsoDataPtr::V5_6(vdso_data_v5_6::vdsodata_ptr(vdso_addr)),
-            (5, 9..=12) => VdsoDataPtr::V5_9(vdso_data_v5_9::vdsodata_ptr(vdso_addr)),
+            (5, 9..=16) => VdsoDataPtr::V5_9(vdso_data_v5_9::vdsodata_ptr(vdso_addr)),
             (_, _) => return_errno!(EINVAL, "Vdso match kernel release failed"),
         })
     }

--- a/src/libos/crates/vdso-time/src/sys.rs
+++ b/src/libos/crates/vdso-time/src/sys.rs
@@ -122,7 +122,7 @@ pub enum VdsoDataPtr {
     V5_3(*const vdso_data_v5_3),
     // === Linux 5.6 - 5.8 ===
     V5_6(*const vdso_data_v5_6),
-    // === Linux 5.9 - 5.12 ===
+    // === Linux 5.9 - 5.16 ===
     V5_9(*const vdso_data_v5_9),
 }
 
@@ -521,7 +521,7 @@ impl VdsoData for vdso_data_v5_6 {
     }
 }
 
-// === Linux 5.9 - 5.12 ===
+// === Linux 5.9 - 5.16 ===
 // struct vdso_data
 
 #[repr(C)]

--- a/src/libos/src/entry/enclave.rs
+++ b/src/libos/src/entry/enclave.rs
@@ -99,9 +99,11 @@ pub extern "C" fn occlum_ecall_init(
         async_rt::task::SpawnOptions::new(async {
             let io_uring = &crate::io_uring::SINGLETON;
             loop {
-                for _ in 0..100 {
-                    io_uring.poll_completions();
+                let mut remain_tries = 100;
+                while remain_tries > 0 && io_uring.poll_completions() == 0 {
+                    remain_tries -= 1;
                 }
+
                 async_rt::sched::yield_().await;
             }
         })


### PR DESCRIPTION
This PR consists of several commits that help improve the performance of `IoUringDisk`. This PR plus setting a reasonably small number of cpus (`occlum run --cpus <cpus>`) can make `IoUringDisk` up to 2X faster than `SyncIoDisk` in fio benchmark.