### PR TITLE
Remove a broken symlink in openjdk 11, fix flink and cluster_serving demo

### DIFF
--- a/demos/cluster_serving/install-dependencies.sh
+++ b/demos/cluster_serving/install-dependencies.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
 
 apt-get update
-apt-get install -y openjdk-11-jdk
+apt-get install -y openjdk-11-jre
 apt-get install -y netcat
+
+#The openjdk has a broken symlink, remove it as a workaround
+rm /usr/lib/jvm/java-11-openjdk-amd64/lib/security/blacklisted.certs
 
 # Redis
 [ -f redis-${REDIS_VERSION}.tar.gz ] || wget http://download.redis.io/releases/redis-${REDIS_VERSION}.tar.gz

--- a/demos/flink/download_flink.sh
+++ b/demos/flink/download_flink.sh
@@ -1,4 +1,6 @@
 apt-get update
-apt-get install -y openjdk-11-jdk
+apt-get install -y openjdk-11-jre
+#The openjdk has a broken symlink, remove it as a workaround
+rm /usr/lib/jvm/java-11-openjdk-amd64/lib/security/blacklisted.certs
 [ -f flink-1.11.3-bin-scala_2.11.tgz ] || wget https://archive.apache.org/dist/flink/flink-1.11.3/flink-1.11.3-bin-scala_2.11.tgz
 [ -d flink-1.11.3 ] || tar -xvzf flink-1.11.3-bin-scala_2.11.tgz


### PR DESCRIPTION
The OpenJDK 11 has a broken symlink, the copy_bom tool is not able to work with this symlink, so remove it.