### PR TITLE
Add clock_nanosleep() syscall

### DIFF
--- a/src/libos/src/entry/syscall.rs
+++ b/src/libos/src/entry/syscall.rs
@@ -186,6 +186,7 @@ macro_rules! process_syscall_table_with_callback {
             (Futex = 202) => do_futex(futex_addr: *const i32, futex_op: u32, futex_val: i32, timeout: u64, futex_new_addr: *const i32, bitset: u32),
             (SchedYield = 24) => do_sched_yield(),
             (Nanosleep = 35) => do_nanosleep(req_u: *const timespec_t, rem_u: *mut timespec_t),
+            (ClockNanosleep = 230) => do_clock_nanosleep(clockid: clockid_t, flags: i32, request: *const timespec_t, remain: *mut timespec_t),
             (SchedSetaffinity = 203) => do_sched_setaffinity(pid: pid_t, cpusize: size_t, buf: *const c_uchar),
             (SchedGetaffinity = 204) => do_sched_getaffinity(pid: pid_t, cpusize: size_t, buf: *mut c_uchar),
             (Getpriority = 140) => do_get_priority(which: i32, who: i32),
@@ -956,6 +957,27 @@ async fn do_nanosleep(req_u: *const timespec_t, rem_u: *mut timespec_t) -> Resul
         None
     };
     crate::time::do_nanosleep(&req, rem).await?;
+    Ok(0)
+}
+
+async fn do_clock_nanosleep(
+    clockid: clockid_t,
+    flags: i32,
+    req_u: *const timespec_t,
+    rem_u: *mut timespec_t,
+) -> Result<isize> {
+    let req = {
+        check_ptr(req_u)?;
+        timespec_t::from_raw_ptr(req_u)?
+    };
+    let rem = if !rem_u.is_null() {
+        check_mut_ptr(rem_u)?;
+        Some(unsafe { &mut *rem_u })
+    } else {
+        None
+    };
+    let clockid = ClockId::try_from(clockid)?;
+    crate::time::do_clock_nanosleep(clockid, flags, &req, rem).await?;
     Ok(0)
 }
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -16,7 +16,7 @@ PASS_LOG = $(BUILD_DIR)/test/.pass
 FAIL_LOG = $(BUILD_DIR)/test/.fail
 
 # Dependencies: need to be compiled but not to run by any Makefile target
-TEST_DEPS := client data_sink naughty_child
+TEST_DEPS := client data_sink naughty_child wait_child
 # Tests: need to be compiled and run by test-% target
 
 TESTS ?= env empty hello_world malloc mmap file fs_perms getpid spawn sched pipe time \

--- a/test/sleep/main.c
+++ b/test/sleep/main.c
@@ -87,10 +87,10 @@ static int timespec_equal(const struct timespec *a, const struct timespec *b,
 // Return SUCCESS(1) if check passed, FAIL(-1) if check failed
 static int check_nanosleep(const struct timespec *expected_sleep_period) {
     // The time obtained from Occlum is not very precise.
-    // Here we take 1 millisecond as the time precision of Occlum.
+    // Here we take 1.5 millisecond as the time precision of Occlum.
     static struct timespec OS_TIME_PRECISION = {
         .tv_sec = 0,
-        .tv_nsec = 1 * MS,
+        .tv_nsec = 1 * MS + 500 * US,
     };
 
     struct timespec begin_timestamp, end_timestamp;

--- a/test/wait/main.c
+++ b/test/wait/main.c
@@ -23,8 +23,8 @@ static int test_wait_nohang() {
     }
 
     int child_pid = 0;
-    // /bin/sleep lasts more than 1 sec
-    if (posix_spawn(&child_pid, "/bin/sleep", NULL, NULL, NULL, NULL) < 0) {
+    // /bin/wait_child lasts for 2 sec
+    if (posix_spawn(&child_pid, "/bin/wait_child", NULL, NULL, NULL, NULL) < 0) {
         THROW_ERROR("posix_spawn child error");
     }
 
@@ -33,7 +33,7 @@ static int test_wait_nohang() {
         THROW_ERROR("wait child with NOHANG error");
     }
 
-    sleep(2);
+    sleep(3);
     // The child process should exit
     ret = waitpid(child_pid, &status, WNOHANG);
     if (ret != child_pid) {

--- a/test/wait_child/Makefile
+++ b/test/wait_child/Makefile
@@ -1,0 +1,5 @@
+include ../test_common.mk
+
+EXTRA_C_FLAGS := -Wno-unused-function
+EXTRA_LINK_FLAGS :=
+BIN_ARGS :=

--- a/test/wait_child/main.c
+++ b/test/wait_child/main.c
@@ -1,0 +1,6 @@
+#include <unistd.h>
+
+int main() {
+    sleep(2);
+    return 0;
+}


### PR DESCRIPTION
1. Fix some bugs in the original test/sleep and adjust the `OS_TIME_PRECISION`;
2. Add clock_nanosleep() syscall;
3. Add simple sleep program in test/wait_child for test/wait (See `test_wait_nohang ()`);
5. Add some test cases for clock_nanosleep() syscall