### PR TITLE
Check the buffer address before copy the data from the buffer

### DIFF
--- a/src/libos/src/util/mem_util.rs
+++ b/src/libos/src/util/mem_util.rs
@@ -69,11 +69,15 @@ pub mod from_user {
             return_errno!(EINVAL, "NULL address is invalid");
         }
 
+        // confirm that at least the fisrt byte of the string is from user
+        check_ptr(out_ptr)?;
+
         let cstr = unsafe { CStr::from_ptr(out_ptr) };
-        let cstring = CString::from(cstr);
-        if !is_inside_user_space(out_ptr as *const u8, cstring.as_bytes().len()) {
+        if !is_inside_user_space(out_ptr as *const u8, cstr.to_bytes_with_nul().len()) {
             return_errno!(EFAULT, "the whole buffer is not in the user space");
         }
+
+        let cstring = CString::from(cstr);
         Ok(cstring)
     }
 
@@ -148,14 +152,18 @@ pub mod from_untrusted {
             return_errno!(EINVAL, "NULL address is invalid");
         }
 
+        // confirm that at least the fisrt byte of the string is out side of enclave
+        check_ptr(out_ptr)?;
+
         let cstr = unsafe { CStr::from_ptr(out_ptr) };
-        let cstring = CString::from(cstr);
         if !sgx_trts::trts::rsgx_raw_is_outside_enclave(
             out_ptr as *const u8,
-            cstring.as_bytes().len(),
+            cstr.to_bytes_with_nul().len(),
         ) {
             return_errno!(EFAULT, "the string is not outside enclave");
         }
+
+        let cstring = CString::from(cstr);
         Ok(cstring)
     }
 


### PR DESCRIPTION
This commit fixed an Occlum security issue. The researchers from KU
Leuven (Belgium) and the University of Birmingham (UK) found it and
reported it to Occlum team. Thank you, Jo Van Bulck, Frank Piessens,
Fritz Alder, David Oswald, Jesse Spielman and Sam Thomas.