### PR TITLE
[libos] Add support for shm

### DIFF
--- a/src/libos/src/entry/enclave.rs
+++ b/src/libos/src/entry/enclave.rs
@@ -217,13 +217,11 @@ pub extern "C" fn occlum_ecall_run_vcpu(pal_data_ptr: *const occlum_pal_vcpu_dat
     let running_vcpu_num = async_rt::executor::run_tasks();
     if running_vcpu_num == 0 {
         // It is the last vcpu for the executor. We can perform some check to make sure there is no resource leakage
-        use crate::vm::USER_SPACE_VM_MANAGER;
         assert!(
             table::get_all_pgrp().len() == 0
                 && table::get_all_processes().len() == 0
                 && table::get_all_threads().len() == 0
         );
-        assert!(USER_SPACE_VM_MANAGER.verified_clean_when_exit());
     }
 
     use rcore_fs::vfs::FileSystem;

--- a/src/libos/src/entry/syscall.rs
+++ b/src/libos/src/entry/syscall.rs
@@ -31,6 +31,7 @@ use crate::fs::{
     FileDesc, FileRef, HostStdioFds, Stat,
 };
 */
+use crate::ipc::{do_shmat, do_shmctl, do_shmdt, do_shmget, key_t, shmids_t};
 use crate::misc::{resource_t, rlimit_t, sysinfo_t, utsname_t, RandFlags};
 use crate::net::{
     do_accept, do_accept4, do_bind, do_connect, do_getpeername, do_getsockname, do_getsockopt,
@@ -185,9 +186,9 @@ macro_rules! process_syscall_table_with_callback {
             (Msync = 26) => do_msync(addr: usize, size: usize, flags: u32),
             (Mincore = 27) => handle_unsupported(),
             (Madvise = 28) => handle_unsupported(),
-            (Shmget = 29) => handle_unsupported(),
-            (Shmat = 30) => handle_unsupported(),
-            (Shmctl = 31) => handle_unsupported(),
+            (Shmget = 29) => do_shmget(key: key_t, size: size_t, shmflg: i32),
+            (Shmat = 30) => do_shmat(shmid: i32, shmaddr: usize, shmflg: i32),
+            (Shmctl = 31) => do_shmctl(shmid: i32, cmd: i32, buf: *mut shmids_t),
             (Dup = 32) => do_dup(old_fd: FileDesc),
             (Dup2 = 33) => do_dup2(old_fd: FileDesc, new_fd: FileDesc),
             (Pause = 34) => handle_unsupported(),
@@ -223,7 +224,7 @@ macro_rules! process_syscall_table_with_callback {
             (Semget = 64) => handle_unsupported(),
             (Semop = 65) => handle_unsupported(),
             (Semctl = 66) => handle_unsupported(),
-            (Shmdt = 67) => handle_unsupported(),
+            (Shmdt = 67) => do_shmdt(shmaddr: usize),
             (Msgget = 68) => handle_unsupported(),
             (Msgsnd = 69) => handle_unsupported(),
             (Msgrcv = 70) => handle_unsupported(),

--- a/src/libos/src/ipc/mod.rs
+++ b/src/libos/src/ipc/mod.rs
@@ -1,0 +1,7 @@
+use super::*;
+
+mod shm;
+mod syscalls;
+
+pub use self::shm::{key_t, shmids_t, SHM_MANAGER};
+pub use self::syscalls::{do_shmat, do_shmctl, do_shmdt, do_shmget};

--- a/src/libos/src/ipc/shm.rs
+++ b/src/libos/src/ipc/shm.rs
@@ -1,0 +1,510 @@
+use super::*;
+
+use crate::fs::FileMode;
+use crate::process::do_getuid::{do_getegid, do_geteuid};
+use crate::process::{gid_t, uid_t, ThreadRef};
+use crate::time::{do_gettimeofday, time_t};
+use crate::vm::{
+    ChunkRef, VMInitializer, VMMapOptionsBuilder, VMPerms, VMRange, USER_SPACE_VM_MANAGER,
+};
+use std::collections::{HashMap, HashSet};
+
+#[allow(non_camel_case_types)]
+pub type key_t = u32;
+pub type ShmId = u32;
+pub type CmdId = u32;
+
+// min shared seg size (bytes)
+const SHMMIN: usize = 1;
+// max shared seg size (bytes)
+const SHMMAX: usize = (usize::MAX - (1_usize << 24));
+// max num of segs system wide,
+// also indicates the max shmid - 1 in Occlum
+const SHMMNI: ShmId = 4096;
+
+const IPC_PRIVATE: key_t = 0;
+
+// For cmd in shmctl()
+const IPC_RMID: CmdId = 0;
+const IPC_SET: CmdId = 1;
+const IPC_STAT: CmdId = 2;
+const IPC_INFO: CmdId = 3;
+const SHM_LOCK: CmdId = 11;
+const SHM_UNLOCK: CmdId = 12;
+const SHM_STAT: CmdId = 13;
+const SHM_INFO: CmdId = 14;
+const SHM_STAT_ANY: CmdId = 15;
+
+#[allow(non_camel_case_types)]
+#[derive(Debug)]
+#[repr(C)]
+struct ipc_perm_t {
+    key: key_t,
+    uid: uid_t,
+    gid: gid_t,
+    cuid: uid_t,
+    cgid: gid_t,
+    mode: u16,
+    pad1: u16,
+    seq: u16,
+    pad2: u16,
+    unused1: u64,
+    unused2: u64,
+}
+
+#[allow(non_camel_case_types)]
+#[derive(Debug)]
+#[repr(C)]
+pub struct shmids_t {
+    shm_perm: ipc_perm_t,
+    shm_segsz: size_t,
+    shm_atime: time_t,
+    shm_dtime: time_t,
+    shm_ctime: time_t,
+    shm_cpid: pid_t,
+    shm_lpid: pid_t,
+    shm_nattach: u64,
+    unused1: u64,
+    unused2: u64,
+}
+
+// shared memory segment status
+bitflags! {
+    struct ShmStatus : u16 {
+        // segment will be destroyed on last detach
+        const SHM_DEST = 0o1000;
+        // segment will not be swapped, unused now
+        const SHM_LOCKED = 0o2000;
+    }
+}
+
+bitflags! {
+    pub struct ShmFlags: u32 {
+        const IPC_CREAT = 0o1000;
+        const IPC_EXCL = 0o2000;
+
+        /// read by owner
+        const S_IRUSR = FileMode::S_IRUSR.bits() as u32;
+        /// write by owner
+        const S_IWUSR = FileMode::S_IWUSR.bits() as u32;
+        /// execute/search by owner
+        const S_IXUSR = FileMode::S_IXUSR.bits() as u32;
+        /// read by group
+        const S_IRGRP = FileMode::S_IRGRP.bits() as u32;
+        /// write by group
+        const S_IWGRP = FileMode::S_IWGRP.bits() as u32;
+        /// execute/search by group
+        const S_IXGRP = FileMode::S_IXGRP.bits() as u32;
+        /// read by others
+        const S_IROTH = FileMode::S_IROTH.bits() as u32;
+        /// write by others
+        const S_IWOTH = FileMode::S_IWOTH.bits() as u32;
+        /// execute/search by others
+        const S_IXOTH = FileMode::S_IXOTH.bits() as u32;
+    }
+}
+
+impl ShmFlags {
+    fn to_file_mode(&self) -> FileMode {
+        let mut shmflgs = *self;
+        shmflgs.remove(ShmFlags::IPC_CREAT);
+        shmflgs.remove(ShmFlags::IPC_EXCL);
+        let file_mode = FileMode::from_bits(shmflgs.bits as u16 & FileMode::all().bits()).unwrap();
+        file_mode
+    }
+}
+
+#[derive(Debug)]
+struct ShmSegment {
+    shmid: ShmId,
+    key: key_t,
+
+    uid: uid_t,
+    gid: gid_t,
+    cuid: uid_t,
+    cgid: gid_t,
+    mode: FileMode,
+    status: ShmStatus,
+
+    shm_atime: time_t,
+    shm_dtime: time_t,
+    shm_ctime: time_t,
+
+    shm_cpid: pid_t,
+    shm_lpid: pid_t,
+
+    shm_nattach: u64,
+    chunk: ChunkRef,
+    process_set: HashSet<pid_t>,
+}
+
+impl ShmSegment {
+    fn new(shmid: ShmId, key: key_t, size: size_t, mode: FileMode) -> Result<Self> {
+        let vm_option = VMMapOptionsBuilder::default()
+            .size(size)
+            // Currently, Occlum only support shared memory segment with rw permission
+            .perms(VMPerms::READ | VMPerms::WRITE)
+            .initializer(VMInitializer::FillZeros())
+            .build()?;
+        let chunk = USER_SPACE_VM_MANAGER.internal().mmap_chunk(&vm_option)?;
+
+        Ok(ShmSegment {
+            shmid: shmid,
+            key: key,
+            uid: do_geteuid() as u32,
+            cuid: do_geteuid() as u32,
+            gid: do_getegid() as u32,
+            cgid: do_getegid() as u32,
+            mode: mode,
+            status: ShmStatus::empty(),
+            shm_atime: 0,
+            shm_dtime: 0,
+            shm_ctime: ShmManager::current_time(),
+            shm_cpid: current!().process().pid(),
+            shm_lpid: 0,
+            shm_nattach: 0,
+            chunk: chunk,
+            process_set: HashSet::new(),
+        })
+    }
+
+    fn check_perm(&self) -> Result<()> {
+        // TODO: Add permission control
+        Ok(())
+    }
+
+    fn set_destruction(&mut self) {
+        self.status.insert(ShmStatus::SHM_DEST)
+    }
+
+    fn is_destruction(&self) -> bool {
+        self.status.contains(ShmStatus::SHM_DEST)
+    }
+
+    fn shm_start(&self) -> usize {
+        self.chunk.range().start()
+    }
+
+    fn shm_size(&self) -> usize {
+        self.chunk.range().size()
+    }
+
+    fn shm_add_pid(&mut self, pid: &pid_t) -> Result<()> {
+        if self.process_set.contains(pid) {
+            return_errno!(EINVAL, "this pid has been attached to the shm");
+        }
+        self.process_set.insert(*pid);
+        Ok(())
+    }
+
+    fn shm_remove_pid(&mut self, pid: &pid_t) -> Result<()> {
+        if !self.process_set.contains(pid) {
+            return_errno!(EINVAL, " this pid has not been attached to the shm");
+        }
+        self.process_set.remove(&pid);
+        Ok(())
+    }
+}
+
+impl Drop for ShmSegment {
+    fn drop(&mut self) {
+        debug!("drop shm: {:?}", self);
+        assert!(self.shm_nattach == 0);
+        assert!(self.process_set.len() == 0);
+        USER_SPACE_VM_MANAGER
+            .internal()
+            .munmap_chunk(&self.chunk, None);
+    }
+}
+
+#[derive(Debug)]
+struct ShmIdManager {
+    used_id: HashSet<ShmId>,
+    free_num: u32,
+    last_alloc_id: ShmId,
+}
+
+impl ShmIdManager {
+    fn new() -> Self {
+        let used_id = HashSet::new();
+        let free_num = SHMMNI as u32;
+        let last_alloc_id = SHMMNI - 1;
+        ShmIdManager {
+            used_id,
+            free_num,
+            last_alloc_id,
+        }
+    }
+
+    // Always return next free id for shmid
+    fn get_new_shmid(&mut self) -> Result<ShmId> {
+        if self.free_num == 0 {
+            return_errno!(ENOSPC, "all possible shared memory IDs have been taken");
+        } else {
+            self.free_num -= 1;
+        }
+        let mut id = self.last_alloc_id + 1;
+        loop {
+            if id == SHMMNI {
+                id = 0;
+            }
+            if !self.used_id.contains(&id) {
+                break;
+            }
+            id += 1;
+        }
+        self.last_alloc_id = id;
+        Ok(id)
+    }
+
+    fn free_shmid(&mut self, shmid: &ShmId) -> Result<()> {
+        self.free_num += 1;
+        self.used_id.remove(shmid);
+        Ok(())
+    }
+}
+
+lazy_static! {
+    pub static ref SHM_MANAGER: ShmManager = ShmManager::new();
+}
+
+#[derive(Debug)]
+pub struct ShmManager {
+    shm_segments: RwLock<HashMap<ShmId, ShmSegment>>,
+    shmid_manager: RwLock<ShmIdManager>,
+}
+
+impl ShmManager {
+    fn new() -> Self {
+        ShmManager {
+            shm_segments: RwLock::new(HashMap::new()),
+            shmid_manager: RwLock::new(ShmIdManager::new()),
+        }
+    }
+
+    fn current_time() -> time_t {
+        do_gettimeofday().sec()
+    }
+
+    fn get_new_shmid(&self) -> Result<ShmId> {
+        let mut shmid_manager = self.shmid_manager.write().unwrap();
+        shmid_manager.get_new_shmid()
+    }
+
+    fn free_shmid(&self, shmid: &ShmId) -> Result<()> {
+        let mut shmid_manager = self.shmid_manager.write().unwrap();
+        shmid_manager.free_shmid(&shmid)
+    }
+
+    fn shmctl_rmshm(&self, shmid: ShmId) -> Result<()> {
+        let mut shm_segments = self.shm_segments.write().unwrap();
+        let shm = shm_segments.get_mut(&shmid);
+
+        if let Some(shm) = shm {
+            shm.shm_ctime = ShmManager::current_time();
+            shm.set_destruction();
+            if shm.shm_nattach == 0 {
+                let shmid = shm.shmid;
+                self.free_shmid(&shmid)?;
+                shm_segments.remove(&shmid);
+            }
+        } else {
+            return_errno!(EINVAL, "cannot find shm by shmid");
+        }
+        Ok(())
+    }
+
+    fn shmctl_ipcstat(&self, shmid: ShmId, buf: Option<&mut shmids_t>) -> Result<()> {
+        let shm_segments = self.shm_segments.read().unwrap();
+        let shm = shm_segments.get(&shmid);
+        if let Some(shm) = shm {
+            shm.check_perm()?;
+            let mut buf = match buf {
+                Some(buf) => buf,
+                None => return_errno!(EFAULT, "buf is empty"),
+            };
+            let shm_perm = ipc_perm_t {
+                key: shm.key,
+                uid: shm.uid,
+                gid: shm.uid,
+                cuid: shm.cuid,
+                cgid: shm.cgid,
+                mode: shm.mode.bits() | shm.status.bits(),
+                pad1: 0,
+                seq: 0,
+                pad2: 0,
+                unused1: 0,
+                unused2: 0,
+            };
+            let shmids = shmids_t {
+                shm_perm: shm_perm,
+                shm_segsz: shm.shm_size(),
+                shm_atime: shm.shm_atime,
+                shm_dtime: shm.shm_dtime,
+                shm_ctime: shm.shm_ctime,
+                shm_cpid: shm.shm_cpid,
+                shm_lpid: shm.shm_lpid,
+                shm_nattach: shm.shm_nattach,
+                unused1: 0,
+                unused2: 0,
+            };
+            *buf = shmids;
+        } else {
+            return_errno!(EINVAL, "cannot find shm by shmid");
+        }
+        Ok(())
+    }
+
+    pub fn do_shmget(&self, key: key_t, size: usize, shmflg: ShmFlags) -> Result<ShmId> {
+        debug!(
+            "do_shmget: key: {:?}, size: {:?}, shmflg: {:?}",
+            key, size, shmflg
+        );
+
+        // Check the size from user
+        if size < SHMMIN || size > SHMMAX {
+            return_errno!(EINVAL, "invalid size");
+        }
+
+        let mut mode = shmflg.to_file_mode();
+        // The creator and user must have the read and write permission to the segment
+        let read_per = mode.contains(FileMode::S_IRUSR)
+            || mode.contains(FileMode::S_IRGRP)
+            || mode.contains(FileMode::S_IROTH);
+        let write_per = mode.contains(FileMode::S_IWUSR)
+            || mode.contains(FileMode::S_IWGRP)
+            || mode.contains(FileMode::S_IWOTH);
+        if !(read_per && write_per) {
+            return_errno!(
+                EINVAL,
+                "shared memory segement in occlum should have rw permission now"
+            );
+        }
+
+        let mut shm_segments = self.shm_segments.write().unwrap();
+        let shmid = if key == IPC_PRIVATE {
+            let shmid = self.get_new_shmid()?;
+            let shm = ShmSegment::new(shmid, key, size, mode)?;
+            shm_segments.insert(shm.shmid, shm);
+            shmid
+        } else {
+            // Get the shm from key if the segment is not marked to be destroyed
+            let shm = shm_segments
+                .values()
+                .find(|&shm| !shm.is_destruction() && shm.key == key);
+            let shmid = if let Some(shm) = shm {
+                if shmflg.contains(ShmFlags::IPC_CREAT) && shmflg.contains(ShmFlags::IPC_EXCL) {
+                    return_errno!(
+                        EEXIST,
+                        "the shared memory segment already exists for given key"
+                    );
+                }
+                // The size from user must be less than the actual size
+                if size > shm.shm_size() {
+                    return_errno!(EINVAL, "the size from user is too large");
+                }
+                // Check the permission
+                shm.check_perm()?;
+                shm.shmid
+            } else {
+                if !shmflg.contains(ShmFlags::IPC_CREAT) {
+                    return_errno!(ENOENT, "no segment exists for given key");
+                }
+                let shmid = self.get_new_shmid()?;
+                let shm = ShmSegment::new(shmid, key, size, mode)?;
+                shm_segments.insert(shm.shmid, shm);
+                shmid
+            };
+            shmid
+        };
+        Ok(shmid)
+    }
+
+    pub fn do_shmat(&self, shmid: ShmId, addr: usize, shmflg: ShmFlags) -> Result<usize> {
+        debug!(
+            "do_shmat: shmid: {:?}, addr: {:?}, shmflg: {:?}",
+            shmid, addr, shmflg
+        );
+        let pid = current!().process().pid();
+        let mut shm_segments = self.shm_segments.write().unwrap();
+        let shm = shm_segments.get_mut(&shmid);
+        let addr = if let Some(shm) = shm {
+            if addr != 0 && addr != shm.shm_start() {
+                return_errno!(EINVAL, "invalid addr");
+            }
+            // Check the permission
+            shm.check_perm()?;
+
+            shm.shm_nattach += 1;
+            shm.shm_atime = ShmManager::current_time();
+            shm.shm_add_pid(&pid)?;
+            shm.shm_lpid = pid;
+            shm.shm_start()
+        } else {
+            return_errno!(EINVAL, "cannot find shm by shmid");
+        };
+        Ok(addr)
+    }
+
+    pub fn do_shmdt(&self, addr: usize) -> Result<()> {
+        debug!("do_shmdt: addr: {:?}", addr);
+        let pid = current!().process().pid();
+        let mut shm_segments = self.shm_segments.write().unwrap();
+        let shm = shm_segments
+            .values_mut()
+            .find(|shm| shm.shm_start() == addr);
+
+        if let Some(shm) = shm {
+            shm.shm_dtime = ShmManager::current_time();
+            shm.shm_lpid = pid;
+            shm.shm_remove_pid(&pid)?;
+            shm.shm_nattach -= 1;
+            if shm.is_destruction() && shm.shm_nattach == 0 {
+                let shmid = shm.shmid;
+                self.free_shmid(&shmid);
+                shm_segments.remove(&shmid);
+            }
+        } else {
+            return_errno!(EINVAL, "cannot find shm by addr");
+        }
+        Ok(())
+    }
+
+    pub fn do_shmctl(&self, shmid: ShmId, cmd: CmdId, buf: Option<&mut shmids_t>) -> Result<()> {
+        debug!(
+            "do_shmctl: shmid: {:?}, cmd: {:?}, buf: {:?}",
+            shmid, cmd, buf
+        );
+        match cmd {
+            IPC_RMID => self.shmctl_rmshm(shmid),
+            IPC_STAT => self.shmctl_ipcstat(shmid, buf),
+            _ => return_errno!(EINVAL, "unimplemented cmd"),
+        }
+    }
+
+    pub fn detach_shm_when_process_exit(&self, thread: &ThreadRef) {
+        let pid = &thread.process().pid();
+        let mut shm_segments = self.shm_segments.write().unwrap();
+        shm_segments.drain_filter(|shmid, shm| match shm.shm_remove_pid(&pid) {
+            // There exists a shm that has been attached to the current process
+            Ok(_) => {
+                shm.shm_nattach -= 1;
+                if shm.is_destruction() && shm.shm_nattach == 0 {
+                    self.free_shmid(&shmid);
+                    true
+                } else {
+                    false
+                }
+            }
+            Err(_) => false,
+        });
+    }
+
+    pub fn clean_when_libos_exit(&self) {
+        let mut shm_segments = self.shm_segments.write().unwrap();
+        for (_, shm) in shm_segments.drain() {
+            debug!("clean shm: {:?}", shm);
+            self.free_shmid(&shm.shmid);
+        }
+    }
+}

--- a/src/libos/src/ipc/syscalls.rs
+++ b/src/libos/src/ipc/syscalls.rs
@@ -1,0 +1,36 @@
+use super::*;
+
+use util::mem_util::from_user;
+
+use super::shm::{shmids_t, CmdId, ShmFlags, ShmId, SHM_MANAGER};
+
+pub async fn do_shmget(key: key_t, size: size_t, shmflg: i32) -> Result<isize> {
+    let shmflg =
+        ShmFlags::from_bits(shmflg as u32).ok_or_else(|| errno!(EINVAL, "invalid flags"))?;
+    let shmid = SHM_MANAGER.do_shmget(key, size, shmflg)?;
+    Ok(shmid as isize)
+}
+
+pub async fn do_shmat(shmid: i32, shmaddr: usize, shmflg: i32) -> Result<isize> {
+    let shmflg =
+        ShmFlags::from_bits(shmflg as u32).ok_or_else(|| errno!(EINVAL, "invalid flags"))?;
+    let addr = SHM_MANAGER.do_shmat(shmid as ShmId, shmaddr, shmflg)?;
+    Ok(addr as isize)
+}
+
+pub async fn do_shmdt(shmaddr: usize) -> Result<isize> {
+    SHM_MANAGER.do_shmdt(shmaddr)?;
+    Ok(0)
+}
+
+pub async fn do_shmctl(shmid: i32, cmd: i32, buf_u: *mut shmids_t) -> Result<isize> {
+    let buf = if !buf_u.is_null() {
+        from_user::check_mut_ptr(buf_u)?;
+        let mut buf = unsafe { &mut *buf_u };
+        Some(buf)
+    } else {
+        None
+    };
+    SHM_MANAGER.do_shmctl(shmid as ShmId, cmd as CmdId, buf)?;
+    Ok(0)
+}

--- a/src/libos/src/lib.rs
+++ b/src/libos/src/lib.rs
@@ -85,6 +85,7 @@ mod config;
 mod entry;
 mod fs;
 mod io_uring;
+mod ipc;
 mod misc;
 mod net;
 mod poll;

--- a/src/libos/src/process/do_exit.rs
+++ b/src/libos/src/process/do_exit.rs
@@ -8,6 +8,7 @@ use super::pgrp::clean_pgrp_when_exit;
 use super::process::{Process, ProcessFilter};
 use super::{table, ProcessRef, TermStatus, ThreadRef, ThreadStatus};
 use crate::entry::context_switch::CURRENT_CONTEXT;
+use crate::ipc::SHM_MANAGER;
 use crate::prelude::*;
 use crate::signal::constants::*;
 use crate::signal::{KernelSignal, SigNum};
@@ -124,6 +125,7 @@ fn exit_process(thread: &ThreadRef, term_status: TermStatus, new_parent_ref: Opt
     let mut process_inner = process.inner();
     // Clean used VM
     USER_SPACE_VM_MANAGER.free_chunks_when_exit(thread);
+    SHM_MANAGER.detach_shm_when_process_exit(thread);
 
     if let Some(new_parent_ref) = new_parent_ref {
         // Exit old process in execve syscall

--- a/src/libos/src/process/do_getuid.rs
+++ b/src/libos/src/process/do_getuid.rs
@@ -1,0 +1,19 @@
+use super::{gid_t, uid_t};
+
+// TODO: implement uid, gid, euid, egid
+
+pub fn do_getuid() -> uid_t {
+    0
+}
+
+pub fn do_getgid() -> gid_t {
+    0
+}
+
+pub fn do_geteuid() -> uid_t {
+    0
+}
+
+pub fn do_getegid() -> gid_t {
+    0
+}

--- a/src/libos/src/process/mod.rs
+++ b/src/libos/src/process/mod.rs
@@ -37,6 +37,7 @@ mod do_exec;
 mod do_exit;
 mod do_futex;
 mod do_getpid;
+pub mod do_getuid;
 mod do_robust_list;
 mod do_set_tid_address;
 mod do_spawn;
@@ -63,6 +64,8 @@ pub mod table;
 pub type pid_t = u32;
 #[allow(non_camel_case_types)]
 pub type uid_t = u32;
+#[allow(non_camel_case_types)]
+pub type gid_t = u32;
 
 pub type ProcessRef = Arc<Process>;
 pub type ThreadRef = Arc<Thread>;

--- a/src/libos/src/process/syscalls.rs
+++ b/src/libos/src/process/syscalls.rs
@@ -460,22 +460,24 @@ pub async fn do_setpgid(pid: i32, pgid: i32) -> Result<isize> {
     Ok(ret)
 }
 
-// TODO: implement uid, gid, euid, egid
-
 pub async fn do_getuid() -> Result<isize> {
-    Ok(0)
+    let uid = super::do_getuid::do_getuid();
+    Ok(uid as isize)
 }
 
 pub async fn do_getgid() -> Result<isize> {
-    Ok(0)
+    let gid = super::do_getuid::do_getgid();
+    Ok(gid as isize)
 }
 
 pub async fn do_geteuid() -> Result<isize> {
-    Ok(0)
+    let euid = super::do_getuid::do_geteuid();
+    Ok(euid as isize)
 }
 
 pub async fn do_getegid() -> Result<isize> {
-    Ok(0)
+    let egid = super::do_getuid::do_getegid();
+    Ok(egid as isize)
 }
 
 pub async fn do_set_robust_list(list_head_ptr: *mut RobustListHead, len: usize) -> Result<isize> {

--- a/src/libos/src/vm/mod.rs
+++ b/src/libos/src/vm/mod.rs
@@ -75,10 +75,12 @@ mod vm_util;
 
 use self::vm_layout::VMLayout;
 
+pub use self::chunk::{Chunk, ChunkRef};
 pub use self::process_vm::{MMapFlags, MRemapFlags, MSyncFlags, ProcessVM, ProcessVMBuilder};
 pub use self::user_space_vm::USER_SPACE_VM_MANAGER;
 pub use self::vm_perms::VMPerms;
 pub use self::vm_range::VMRange;
+pub use self::vm_util::{VMInitializer, VMMapOptionsBuilder};
 
 pub fn do_mmap(
     addr: usize,

--- a/src/libos/src/vm/user_space_vm.rs
+++ b/src/libos/src/vm/user_space_vm.rs
@@ -1,3 +1,4 @@
+use super::ipc::SHM_MANAGER;
 use super::*;
 use crate::ctor::dtor;
 use config::LIBOS_CONFIG;
@@ -46,6 +47,7 @@ impl UserSpaceVMManager {
 // be called after the main function. Static variables are still safe to visit at this time.
 #[dtor]
 fn free_user_space() {
+    SHM_MANAGER.clean_when_libos_exit();
     let range = USER_SPACE_VM_MANAGER.range();
     assert!(USER_SPACE_VM_MANAGER.verified_clean_when_exit());
     let addr = range.start() as *const c_void;

--- a/test/Makefile
+++ b/test/Makefile
@@ -23,7 +23,7 @@ TESTS ?= env empty hello_world malloc mmap file fs_perms getpid spawn sched pipe
 	truncate readdir mkdir open stat link symlink chmod chown tls pthread system_info rlimit \
 	server server_epoll unix_socket cout hostfs cpuid rdtsc device sleep exit_group posix_flock \
 	ioctl fcntl eventfd emulate_syscall access signal prctl rename procfs wait flock \
-	spawn_attribute exec statfs random umask pgrp vfork mount sysinfo timerfd utimes
+	spawn_attribute exec statfs random umask pgrp vfork mount sysinfo timerfd utimes shm
 
 # Benchmarks: need to be compiled and run by bench-% target
 BENCHES := spawn_and_exit_latency pipe_throughput unix_socket_throughput

--- a/test/shm/Makefile
+++ b/test/shm/Makefile
@@ -1,0 +1,5 @@
+include ../test_common.mk
+
+EXTRA_C_FLAGS :=
+EXTRA_LINK_FLAGS :=
+BIN_ARGS :=

--- a/test/shm/main.c
+++ b/test/shm/main.c
@@ -1,0 +1,414 @@
+#define _GNU_SOURCE
+#include <sys/ipc.h>
+#include <sys/shm.h>
+#include <sys/syscall.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <fcntl.h>
+#include <time.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <spawn.h>
+#include <unistd.h>
+#include "test.h"
+
+// ============================================================================
+// Global definitions
+// ============================================================================
+
+#define S_IRWUSER   (S_IRUSR | S_IWUSR)
+
+#define TEST_GET_SHMID_BY_KEY   0
+#define TEST_PROCESS_COMMU      1
+#define TEST_OPERATE_DESTOYED   2
+
+#define TEST_GET_SHMID_BY_KEY_ARGC  5
+#define TEST_PROCESS_COMMU_ARGC     4
+#define TEST_OPERATE_DESTOYED_ARGC  5
+
+#define ARG_BUF_SZ  64
+#define PAGE_SIZE   (0x1000)
+
+#define SUCCESS     1
+#define FAIL        (-1)
+
+const char prog_name[] = "/bin/shm";
+
+// ============================================================================
+// Helper macro and function
+// ============================================================================
+#define INFO(fmt, ...)   do { \
+    printf("\t\t[file: %s, line: %d, func: %s] " fmt, \
+    __FILE__, __LINE__, __func__, ##__VA_ARGS__); \
+} while (0)
+
+// Spawn child, and check the return value from child
+// Return `SUCCESS` if the execution succeeds,
+// return `FAIL` if fails
+static int execute_in_child(char **const child_argv) {
+    int ret;
+    pid_t child_pid;
+    int child_status;
+
+    ret = posix_spawn(&child_pid, prog_name, NULL, NULL, (char **const)child_argv, NULL);
+    if (ret < 0) {
+        THROW_ERROR("Failed to spawn a child process");
+    }
+    ret = waitpid(child_pid, &child_status, 0);
+    if (ret < 0) {
+        THROW_ERROR("Failed to waitpid() for child process");
+    }
+    if (!WIFEXITED(child_status) || WEXITSTATUS(child_status) != 0) {
+        INFO("The test in child failed\n");
+        return FAIL;
+    }
+
+    return SUCCESS;
+}
+
+// ============================================================================
+// Test cases for shm
+// ============================================================================
+static int test_shmget_shmid_from_key(void) {
+    int ret, shmid;
+    key_t key;
+    size_t shm_size = PAGE_SIZE;
+    char *child_argv[TEST_GET_SHMID_BY_KEY_ARGC + 1];
+
+    srand(time(NULL));
+    key = random();
+    // Get a non-existent shm segment, should get the return value with ENOENT
+    ret = syscall(SYS_shmget, key, shm_size, S_IRWUSER);
+    if (ret != -1 || errno != ENOENT) {
+        INFO("shmget() should return ENOENT because the segment does not exist, ret: %d errno: %d\n",
+             ret, errno);
+        return FAIL;
+    }
+
+    // Create a new shm segment
+    shmid = syscall(SYS_shmget, key, shm_size, IPC_CREAT | IPC_EXCL | S_IRWUSER);
+    if (shmid < 0) {
+        THROW_ERROR("shmget() cannot create the shm");
+    }
+
+    // Get the shmid by key in the same process
+    ret = syscall(SYS_shmget, key, shm_size, S_IRWUSER);
+    if (ret < 0) {
+        THROW_ERROR("shmget() cannot get the shm");
+    }
+    if (ret != shmid) {
+        INFO("shmid mismatches, correct: %d actual: %d\n", shmid, ret);
+        return FAIL;
+    }
+
+    // Create a shm segment whose key is already attached to existed segment,
+    // should get the return value with EEXIST
+    ret = syscall(SYS_shmget, key, shm_size, IPC_CREAT | IPC_EXCL | S_IRWUSER);
+    if (ret != -1 || errno != EEXIST) {
+        INFO("shmget() should return EEXIST because the segment already exists, ret: %d errno: %d\n",
+             ret, errno);
+        return FAIL;
+    }
+
+    // Spawn a new process
+    for (int i = 0; i < TEST_GET_SHMID_BY_KEY_ARGC; i++) {
+        child_argv[i] = (char *)malloc(ARG_BUF_SZ);
+    }
+    snprintf(child_argv[0], ARG_BUF_SZ, "%s", prog_name);
+    snprintf(child_argv[1], ARG_BUF_SZ, "%d", TEST_GET_SHMID_BY_KEY);
+    snprintf(child_argv[2], ARG_BUF_SZ, "%d", key);
+    snprintf(child_argv[3], ARG_BUF_SZ, "%d", shmid);
+    snprintf(child_argv[4], ARG_BUF_SZ, "%ld", shm_size);
+    child_argv[TEST_GET_SHMID_BY_KEY_ARGC] = NULL;
+    if ((ret = execute_in_child(child_argv)) != SUCCESS) {
+        return FAIL;
+    }
+    for (int i = 0; i < TEST_GET_SHMID_BY_KEY_ARGC; i++) {
+        free(child_argv[i]);
+    }
+
+    ret = syscall(SYS_shmctl, shmid, IPC_RMID, NULL);
+    if (ret < 0) {
+        THROW_ERROR("Cannot remove the segment");
+    }
+    return SUCCESS;
+}
+
+static int test_process_communication() {
+    int shmid, ret;
+    size_t shm_size = PAGE_SIZE;
+    long random_num, *shm_addr;
+    char *child_argv[TEST_PROCESS_COMMU_ARGC + 1];
+
+    shmid = syscall(SYS_shmget, IPC_PRIVATE, shm_size, IPC_CREAT | IPC_EXCL | S_IRWUSER);
+    if (shmid < 0) {
+        THROW_ERROR("shmget() cannot get the shm");
+    }
+    shm_addr = (long *)syscall(SYS_shmat, shmid, NULL, 0);
+    if (shm_addr == (long *) -1) {
+        THROW_ERROR("shmat() cannot attach the shm");
+    }
+    srandom(time(NULL));
+    random_num = random();
+    *shm_addr = random_num;
+
+    // Spawn a new process
+    for (int i = 0; i < TEST_PROCESS_COMMU_ARGC; i++) {
+        child_argv[i] = (char *)malloc(ARG_BUF_SZ);
+    }
+    snprintf(child_argv[0], ARG_BUF_SZ, "%s", prog_name);
+    snprintf(child_argv[1], ARG_BUF_SZ, "%d", TEST_PROCESS_COMMU);
+    snprintf(child_argv[2], ARG_BUF_SZ, "%d", shmid);
+    snprintf(child_argv[3], ARG_BUF_SZ, "%ld", random_num);
+    child_argv[TEST_PROCESS_COMMU_ARGC] = NULL;
+    if ((ret = execute_in_child(child_argv)) != SUCCESS) {
+        return FAIL;
+    }
+    for (int i = 0; i < TEST_PROCESS_COMMU_ARGC; i++) {
+        free(child_argv[i]);
+    }
+
+    ret = syscall(SYS_shmdt, (void *)shm_addr);
+    if (ret != 0) {
+        THROW_ERROR("shmdt() failed");
+    }
+
+    ret = syscall(SYS_shmctl, shmid, IPC_RMID, NULL);
+    if (ret < 0) {
+        THROW_ERROR("Cannot remove the segment");
+    }
+
+    return SUCCESS;
+}
+
+static int test_immediately_rmshm() {
+    int ret, shmid;
+    size_t shm_size = PAGE_SIZE;
+    struct shmid_ds buf;
+
+    shmid = syscall(SYS_shmget, IPC_PRIVATE, shm_size, IPC_CREAT | IPC_EXCL | S_IRWUSER);
+    if (shmid < 0) {
+        THROW_ERROR("shmget() cannot get the shm");
+    }
+
+    ret = syscall(SYS_shmctl, shmid, IPC_RMID, NULL);
+    if (ret < 0) {
+        THROW_ERROR("Cannot remove the segment");
+    }
+    ret = syscall(SYS_shmctl, shmid, IPC_STAT, NULL);
+    if (ret != -1 || errno != EINVAL) {
+        INFO("Should get errno with EINVAL even though the buf is empty, ret: %d errno: %d\n",
+             ret, errno);
+        return FAIL;
+    }
+    ret = syscall(SYS_shmctl, shmid, IPC_STAT, &buf);
+    if (ret != -1 || errno != EINVAL) {
+        INFO("The shared memory segment should be removed immediately since shm_nattach equals to 0, ret: %d errno: %d\n",
+             ret, errno);
+        return FAIL;
+    }
+
+    return SUCCESS;
+}
+
+static int test_operate_destroyed_shm() {
+    int shmid, ret;
+    size_t shm_size = PAGE_SIZE;
+    void *shm_addr;
+    key_t key;
+    char *child_argv[TEST_OPERATE_DESTOYED_ARGC + 1];
+
+    srand(time(NULL));
+    key = random();
+    shmid = syscall(SYS_shmget, key, shm_size, IPC_CREAT | IPC_EXCL | S_IRWUSER);
+    if (shmid < 0) {
+        THROW_ERROR("shmget() cannot get the shm");
+    }
+    shm_addr = (void *)syscall(SYS_shmat, shmid, NULL, 0);
+    if (shm_addr == (void *) -1) {
+        THROW_ERROR("shmat() cannot attach the shm");
+    }
+
+    // Mark the shared memory segment to be destroyed first
+    ret = syscall(SYS_shmctl, shmid, IPC_RMID, NULL);
+
+    // Spawn a new process
+    for (int i = 0; i < TEST_OPERATE_DESTOYED_ARGC; i++) {
+        child_argv[i] = (char *)malloc(ARG_BUF_SZ);
+    }
+    snprintf(child_argv[0], ARG_BUF_SZ, "%s", prog_name);
+    snprintf(child_argv[1], ARG_BUF_SZ, "%d", TEST_OPERATE_DESTOYED);
+    snprintf(child_argv[2], ARG_BUF_SZ, "%d", key);
+    snprintf(child_argv[3], ARG_BUF_SZ, "%ld", shm_size);
+    snprintf(child_argv[4], ARG_BUF_SZ, "%d", shmid);
+    child_argv[TEST_OPERATE_DESTOYED_ARGC] = NULL;
+    if ((ret = execute_in_child(child_argv)) != SUCCESS) {
+        return FAIL;
+    }
+    for (int i = 0; i < TEST_OPERATE_DESTOYED_ARGC; i++) {
+        free(child_argv[i]);
+    }
+
+    ret = syscall(SYS_shmdt, shm_addr);
+
+    return SUCCESS;
+}
+
+// test_no_rmshm() should be place as the last test case
+//
+// Occlum checks whether all the memory segment is recycled when the LibOS exits,
+// to detect and prevent memory leaks.
+// Such test checks whether all the vmas allocated by `shm mod` are recycled when the LibOS exits,
+// even though no IPC_RMID is invoked for the shared memory segment.
+static int test_no_rmshm() {
+    int shmid;
+    size_t shm_size = PAGE_SIZE;
+    void *shm_addr;
+
+    shmid = syscall(SYS_shmget, IPC_PRIVATE, shm_size, IPC_CREAT | IPC_EXCL | S_IRWUSER);
+    if (shmid < 0) {
+        THROW_ERROR("shmget() cannot get the shm");
+    }
+    shm_addr = (void *)syscall(SYS_shmat, shmid, NULL, 0);
+    if (shm_addr == (long *) -1) {
+        THROW_ERROR("shmat() cannot attach the shm");
+    }
+
+    return SUCCESS;
+}
+
+// ============================================================================
+// Funtion invoked in child process for inter-process communication
+// ============================================================================
+
+static int child_test_get_shmid_by_key(int argc, const char *argv[]) {
+    key_t key;
+    int ret, shmid;
+    size_t shm_size;
+
+    if (argc != TEST_GET_SHMID_BY_KEY_ARGC) {
+        INFO("Invalid argument, argc: %d\n", argc);
+        return FAIL;
+    }
+    key = atoi(argv[2]);
+    shmid = atoi(argv[3]);
+    shm_size = atol(argv[4]);
+
+    // Get the shmid by the key input from parent process
+    ret = syscall(SYS_shmget, key, shm_size, S_IRWUSER);
+    if (ret < 0) {
+        THROW_ERROR("shmget() cannot get the shm");
+    }
+    if (ret != shmid) {
+        INFO("shmid get in child process mismatches that in parent process, correct: %d actual: %d\n",
+             shmid, key);
+        return FAIL;
+    }
+
+    return SUCCESS;
+}
+
+static int child_test_process_communication(int argc, const char *argv[]) {
+    int shmid, ret;
+    long random_num, *shm_ptr;
+
+    if (argc != TEST_PROCESS_COMMU_ARGC) {
+        INFO("Invalid argument, argc: %d\n", argc);
+        return FAIL;
+    }
+    shmid = atoi(argv[2]);
+    random_num = atol(argv[3]);
+
+    // Check whether the value in the shared memory segment equals to
+    // that written in parent process
+    shm_ptr = (long *)syscall(SYS_shmat, shmid, NULL, 0);
+    if (shm_ptr == (long *) -1) {
+        THROW_ERROR("shmat() cannot attach to the shm");
+    }
+    if (*shm_ptr != random_num) {
+        INFO("Data in shm mismatches, correct: %ld actual: %ld\n", random_num, *shm_ptr);
+        return FAIL;
+    }
+
+    ret = syscall(SYS_shmdt, (void *)shm_ptr);
+    if (ret != 0) {
+        THROW_ERROR("shmdt() failed");
+    }
+
+    return SUCCESS;
+}
+
+static int child_test_operate_destroyed_shm(int argc, const char *argv[]) {
+    int shmid, ret;
+    key_t key;
+    size_t shm_size;
+    void *shm_addr;
+
+    if (argc != TEST_OPERATE_DESTOYED_ARGC) {
+        INFO("Invalid argument, argc: %d\n", argc);
+        return FAIL;
+    }
+    key = atoi(argv[2]);
+    shm_size = atol(argv[3]);
+    shmid = atoi(argv[4]);
+
+    ret = syscall(SYS_shmget, key, shm_size, S_IRWUSER);
+    if (ret != -1 || errno != ENOENT) {
+        INFO("shmget() should return ENOENT because the segment is marked to be destoyed, ret: %d errno: %d\n",
+             ret, errno);
+        return FAIL;
+    }
+
+    shm_addr = (void *)syscall(SYS_shmat, shmid, NULL, 0);
+    if (shm_addr == (void *) -1) {
+        THROW_ERROR("shmat() cannot attach the shm");
+    }
+
+    if ((ret = syscall(SYS_shmdt, shm_addr)) != 0) {
+        THROW_ERROR("shmdt() failed");
+    }
+
+    return SUCCESS;
+}
+
+// ============================================================================
+// Test suite main
+// ============================================================================
+
+static test_case_t test_cases[] = {
+    TEST_CASE(test_shmget_shmid_from_key),
+    TEST_CASE(test_process_communication),
+    TEST_CASE(test_immediately_rmshm),
+    TEST_CASE(test_operate_destroyed_shm),
+    // test_no_rmshm() should be place as the last test case
+    TEST_CASE(test_no_rmshm),
+};
+
+int main(int argc, const char *argv[]) {
+    if (argc == 1) {
+        // Parent process will arrive here
+        return test_suite_run(test_cases, ARRAY_SIZE(test_cases));
+    } else {
+        // Child process will arrive here
+        int option = atoi(argv[1]), ret;
+        switch (option) {
+            case TEST_GET_SHMID_BY_KEY:
+                ret = child_test_get_shmid_by_key(argc, argv);
+                break;
+            case TEST_PROCESS_COMMU:
+                ret = child_test_process_communication(argc, argv);
+                break;
+            case TEST_OPERATE_DESTOYED:
+                ret = child_test_operate_destroyed_shm(argc, argv);
+                break;
+            default:
+                INFO("Invalid option: %d\n", option);
+                ret = FAIL;
+        }
+        if (ret == SUCCESS) {
+            return 0;
+        } else {
+            return -1;
+        }
+    }
+}


### PR DESCRIPTION
1. Add support for System V shared memory;
2. Add some tests for it.

More details are shown in the [issue page](https://github.com/occlum/occlum/issues/863)

**Other changes**: 
1. Add new file `src/libos/src/process/do_getuid.rs`, and move the implementaion of `do_getgid()`, `do_getegid()`, `do_getuid()` and `do_geteuid()` to `src/libos/src/process/do_getuid.rs`, since the `Shm::newshm()` in `src/libos/src/ipc/shm.rs` needs to invoke `no async` `do_euid()` and `do_egid()`;

2. Remove duplicate check `USER_SPACE_VM_MANAGER.verified_clean_when_exit()` in `src/libos/entry/main.rs` ([details](https://github.com/occlum/ngo/compare/beb1d1c410a8831938544021eb83129e21c533d0..0b061993c1585b8bae394259d941f2814b2bfa2a)), such check has been performed in `src/libos/src/vm/user_space_vm.rs: free_user_space()`.