### PR TITLE
Identify and fix performance issues in async code

### DIFF
--- a/src/libos/crates/Cargo.toml
+++ b/src/libos/crates/Cargo.toml
@@ -13,18 +13,22 @@ members = [
     "object-id",
     "sgx-disk",
     "sgx-untrusted-alloc",
-    "vdso-time",
+    "vdso-time"
 ]
 
 # Default members can run on Linux; non-default members can only run inside SGX.
 default-members = [
     "async-rt",
+    "async-io",
+    "block-device",
+    "host-socket",
     "inherit-methods-macro",
     "io-uring-callback",
     "keyable-arc",
     "new-self-ref-arc",
-    "vdso-time",
-    "host-socket"
+    "object-id",
+    "sgx-disk",
+    "vdso-time"
 ]
 
 exclude = [ 

--- a/src/libos/crates/async-file/examples/common/bench.rs
+++ b/src/libos/crates/async-file/examples/common/bench.rs
@@ -204,9 +204,6 @@ fn init_async_rt() {
     async_rt::config::set_parallelism(1);
 
     let ring = &runtime::RING;
-    unsafe {
-        ring.start_enter_syscall_thread();
-    }
     let callback = move || {
         ring.trigger_callbacks();
     };

--- a/src/libos/crates/async-io/src/event/event_counter.rs
+++ b/src/libos/crates/async-io/src/event/event_counter.rs
@@ -67,7 +67,7 @@ mod tests {
         async_rt::task::block_on(async {
             let counter = EventCounter::new();
             counter.write();
-            assert!(counter.read().await == 1);
+            assert!(counter.read().await.unwrap() == 1);
         });
     }
 
@@ -80,7 +80,7 @@ mod tests {
             let handle = {
                 let counter = counter.clone();
                 async_rt::task::spawn(async move {
-                    assert!(counter.read().await == 1);
+                    assert!(counter.read().await.unwrap() == 1);
                 })
             };
 

--- a/src/libos/crates/async-io/src/event/mod.rs
+++ b/src/libos/crates/async-io/src/event/mod.rs
@@ -47,7 +47,7 @@
 //!         loop {
 //!             // Try to push
 //!             let mask = Events::OUT; // = writable or the queue is empty
-//!             let is_writable = !self.pollee.poll(mask, poller.as_mut()).is_empty();
+//!             let is_writable = !self.pollee.poll(mask, poller.as_ref()).is_empty();
 //!             if is_writable {
 //!                 let mut slot = self.slot.lock().unwrap();
 //!                 if slot.is_none() {
@@ -74,7 +74,7 @@
 //!         loop {
 //!             // Try to pop
 //!             let mask = Events::IN; // = readable or the queue has an item
-//!             let is_readable = !self.pollee.poll(mask, poller.as_mut()).is_empty();
+//!             let is_readable = !self.pollee.poll(mask, poller.as_ref()).is_empty();
 //!             if is_readable {
 //!                 let mut slot = self.slot.lock().unwrap();
 //!                 let item = slot.take();
@@ -105,7 +105,7 @@
 //!     ///
 //!     /// By providing this method, a poller can now monitor multiple instances of
 //!     /// `OneItemQueue`.
-//!     pub fn poll(&self, mask: Events, poller: Option<&mut Poller>) -> Events {
+//!     pub fn poll(&self, mask: Events, poller: Option<&Poller>) -> Events {
 //!         self.pollee.poll(mask, poller)
 //!     }
 //! }

--- a/src/libos/crates/async-io/src/lib.rs
+++ b/src/libos/crates/async-io/src/lib.rs
@@ -20,3 +20,12 @@ pub mod ioctl;
 pub mod prelude;
 pub mod socket;
 pub mod util;
+
+#[cfg(test)]
+mod tests {
+    #[ctor::ctor]
+    fn auto_init_executor() {
+        const TEST_PARALLELISM: u32 = 2;
+        async_rt::config::set_parallelism(TEST_PARALLELISM);
+    }
+}

--- a/src/libos/crates/async-rt/src/bench/mod.rs
+++ b/src/libos/crates/async-rt/src/bench/mod.rs
@@ -1,0 +1,172 @@
+//! A simple benchmark utility for async code.
+//!
+//! Rust's standard benchmark utility (i.e., `Bencher`) cannot be used to
+//! benchmark async Rust code as async Rust code cannot be runned within a sync
+//! textual context (as provided by `Bencher`). While there are some crates that can
+//! help in this regard, it cannot be ported to SGX easily.
+//!
+//! To workaround the limitation, we provide `async_bench_iter`, a convenient
+//! macro that can benchmark the async Rust code.
+//!
+//! ```ignore
+//! use test::{Bencher};
+//! use async_rt::async_bench_iter;
+//!
+//! #[bench]
+//! fn bench_yield(b: &mut Bencher) {
+//!     async_bench_iter!(b, async || {
+//!         crate::sched::yield_().await;
+//!     });
+//! }
+//! ```
+//!
+//! The main advantage of `async_bench_iter` is that it is easy to use
+//! and leverages `Bencher` under the hood to measure elapsed time and collect
+//! performance metrics. Thus, `cargo bench` outputs the benchmark results
+//! of a code snippet benched by `async_bench_iter` in the same format as if
+//! it was benched by `Bencher`.
+//!
+//! The downside of `async_bench_iter` is that it incurs some overhead
+//! (around 200ns on a 3rd Generation Intel Xeon Scalable Processors at 2.7GHz).
+//! So the macro is not suited for measuring extremely light-weight operations.
+
+use std::hint::{self};
+use std::result::Result;
+
+use atomic::{Atomic, Ordering::*};
+
+/// A macro to benchmark async Rust code.
+#[macro_export]
+macro_rules! async_bench_iter {
+    ($bencher: expr, async move $code:expr) => {{
+        use std::sync::Arc;
+        use std::thread::{self};
+        use test::{black_box, Bencher};
+
+        use $crate::bench::{BenchState, StateSync};
+        use $crate::task::{self};
+
+        // Step 0
+        let state_sync = Arc::new(StateSync::new(BenchState::BenchEnd));
+
+        // Spawn the benchmark helper thread
+        let handle = {
+            let state_sync = state_sync.clone();
+            thread::spawn(move || {
+                task::block_on(async move {
+                    // Step 1
+                    state_sync.switch_to(BenchState::BenchStart);
+                    loop {
+                        // Step 4
+                        if let Err(state) = state_sync.try_busy_wait(BenchState::FuncStart, 1000) {
+                            match state {
+                                // Step 9
+                                BenchState::BenchEnd => {
+                                    break;
+                                }
+                                _ => {
+                                    $crate::sched::yield_().await;
+                                    continue;
+                                }
+                            }
+                        }
+
+                        // Step 5
+                        black_box($code);
+
+                        // Step 6
+                        state_sync.switch_to(BenchState::FuncEnd);
+                    }
+                });
+            })
+        };
+
+        // Step 2
+        state_sync.busy_wait(BenchState::BenchStart);
+
+        // Continue with the benchmark initiater thread
+        let bencher: &mut Bencher = $bencher;
+        bencher.iter({
+            let state_sync = state_sync.clone();
+            move || {
+                // Step 3
+                state_sync.switch_to(BenchState::FuncStart);
+
+                // Let the async task execute the bench function...
+
+                // Step 7 (afterwards, repeat Step 3 or go to Step 8)
+                state_sync.busy_wait(BenchState::FuncEnd);
+            }
+        });
+
+        // Step 8
+        state_sync.switch_to(BenchState::BenchEnd);
+
+        // Step 10
+        handle.join().unwrap();
+    }};
+}
+
+/// The state of an async benchmark enabled by `async_bench_iter`.
+/// This type is not for external use.
+#[doc(hidden)]
+#[derive(Copy, Clone, PartialEq, Eq)]
+pub enum BenchState {
+    BenchStart,
+    FuncStart,
+    FuncEnd,
+    BenchEnd,
+}
+
+/// State synchronization between the two threads spawned by `async_bench_iter`.
+/// This type is not for external use.
+#[doc(hidden)]
+pub struct StateSync<S> {
+    state: Atomic<S>,
+}
+
+impl<S: Copy + PartialEq> StateSync<S> {
+    pub fn new(init_state: S) -> Self {
+        Self {
+            state: Atomic::new(init_state),
+        }
+    }
+
+    pub fn switch_to(&self, new_state: S) {
+        self.state.store(new_state, Relaxed);
+    }
+
+    pub fn busy_wait(&self, target_state: S) {
+        while self.state.load(Relaxed) != target_state {
+            hint::spin_loop();
+        }
+    }
+
+    pub fn try_busy_wait(&self, target_state: S, mut max_retries: usize) -> Result<(), S> {
+        let mut now_state;
+        loop {
+            now_state = self.state.load(Relaxed);
+            if now_state == target_state {
+                return Ok(());
+            }
+            if max_retries == 0 {
+                return Err(now_state);
+            }
+            max_retries -= 1;
+            hint::spin_loop();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use test::Bencher;
+
+    #[bench]
+    fn bench_nop(b: &mut Bencher) {
+        // Let's measure the overhead that the async_bench_iter macro incurs.
+        async_bench_iter!(b, async move {
+            // Do nothing
+        });
+    }
+}

--- a/src/libos/crates/async-rt/src/time/instant.rs
+++ b/src/libos/crates/async-rt/src/time/instant.rs
@@ -110,6 +110,7 @@ impl SubAssign<Duration> for Instant {
 mod tests {
     use super::{Duration, Instant};
     use std::thread;
+    use test::Bencher;
 
     #[test]
     fn test_instant() {
@@ -121,5 +122,10 @@ mod tests {
         let elapsed = start.elapsed();
         assert!(elapsed.as_millis() as u64 >= ms - 1);
         assert!(elapsed.as_millis() as u64 <= ms + 1);
+    }
+
+    #[bench]
+    fn bench_instant(b: &mut Bencher) {
+        b.iter(|| Instant::now());
     }
 }

--- a/src/libos/crates/async-socket/examples/common/tcp_echo.rs
+++ b/src/libos/crates/async-socket/examples/common/tcp_echo.rs
@@ -58,7 +58,12 @@ async fn tcp_echo(port: u16) {
 }
 
 lazy_static! {
-    static ref RING: Arc<IoUring> = Arc::new(Builder::new().build(4096).unwrap());
+    static ref RING: Arc<IoUring> = Arc::new(
+        Builder::new()
+            .setup_sqpoll(Some(500/* ms */))
+            .build(4096)
+            .unwrap()
+        );
 }
 
 struct IoUringInstanceType {}
@@ -75,9 +80,6 @@ fn init_async_rt(parallelism: u32) {
     async_rt::config::set_parallelism(parallelism);
 
     let ring = RING.clone();
-    unsafe {
-        ring.start_enter_syscall_thread();
-    }
     let callback = move || {
         ring.trigger_callbacks();
     };

--- a/src/libos/crates/block-device/src/block_device_ext.rs
+++ b/src/libos/crates/block-device/src/block_device_ext.rs
@@ -114,11 +114,6 @@ impl<'a> Impl<'a> {
         let req = submission.complete().await;
         let res = req.response().unwrap();
 
-        // When this function returns, the buffers associated with the request
-        // will become invalid. So we add this guard to ensure that the block device
-        // does not hold any reference to the Arc<BioReq> for some unknown reason.
-        debug_assert!(Arc::strong_count(&req) == 1);
-
         if let Err(e) = res {
             return Err(errno!(e.errno(), "read on a block device failed"));
         }
@@ -226,8 +221,6 @@ impl<'a> Impl<'a> {
         let req = submission.complete().await;
         let res = req.response().unwrap();
 
-        debug_assert!(Arc::strong_count(&req) == 1);
-
         if let Err(e) = res {
             return Err(errno!(e.errno(), "read on a block device failed"));
         }
@@ -307,8 +300,6 @@ impl<'a> Impl<'a> {
         let submission = self.disk.submit(Arc::new(req));
         let req = submission.complete().await;
         let res = req.response().unwrap();
-
-        debug_assert!(Arc::strong_count(&req) == 1);
 
         if let Err(e) = res {
             return Err(errno!(e.errno(), "write on a block device failed"));
@@ -445,8 +436,6 @@ impl<'a> Impl<'a> {
         let submission = self.disk.submit(Arc::new(req));
         let req = submission.complete().await;
         let res = req.response().unwrap();
-
-        debug_assert!(Arc::strong_count(&req) == 1);
 
         if let Err(e) = res {
             return Err(errno!(e.errno(), "write on a block device failed"));

--- a/src/libos/crates/host-socket/tests/echo.rs
+++ b/src/libos/crates/host-socket/tests/echo.rs
@@ -100,11 +100,8 @@ mod runtime {
                 unsafe {
                     ring.start_enter_syscall_thread();
                 }
-                async_rt::task::spawn(async move {
-                    loop {
-                        ring.poll_completions();
-                        async_rt::sched::yield_().await;
-                    }
+                std::thread::spawn(move || loop {
+                    ring.poll_completions(1, 5000);
                 });
             });
         }

--- a/src/libos/crates/host-socket/tests/echo.rs
+++ b/src/libos/crates/host-socket/tests/echo.rs
@@ -97,9 +97,6 @@ mod runtime {
                 async_rt::config::set_parallelism(parallelism);
 
                 let ring = Self::io_uring();
-                unsafe {
-                    ring.start_enter_syscall_thread();
-                }
                 std::thread::spawn(move || loop {
                     ring.poll_completions(1, 5000);
                 });
@@ -108,7 +105,10 @@ mod runtime {
     }
 
     lazy_static::lazy_static! {
-        static ref IO_URING: IoUring = IoUringBuilder::new().build(4096).unwrap();
+        static ref IO_URING: IoUring = IoUringBuilder::new()
+            .setup_sqpoll(Some(500/* ms */))
+            .build(4096)
+            .unwrap();
     }
 
     impl Runtime for SocketRuntime {

--- a/src/libos/crates/io-uring-callback/examples/sgx/enclave/src/lib.rs
+++ b/src/libos/crates/io-uring-callback/examples/sgx/enclave/src/lib.rs
@@ -109,8 +109,10 @@ pub extern "C" fn run_sgx_example() -> sgx_status_t {
     // std::backtrace::enable_backtrace("enclave.signed.so", std::backtrace::PrintFormat::Full);
     println!("[ECALL] run_sgx_example");
 
-    let ring = Builder::new().build(256).unwrap();
-    unsafe { ring.start_enter_syscall_thread(); }
+    let ring = Builder::new()
+        .setup_sqpoll(Some(500/* ms */))
+        .build(256)
+        .unwrap();
 
     let socket_fd = {
         let socket_fd = unsafe { libc::ocall::socket(libc::AF_INET, libc::SOCK_STREAM, 0) };

--- a/src/libos/crates/io-uring-callback/examples/tcp_echo.rs
+++ b/src/libos/crates/io-uring-callback/examples/tcp_echo.rs
@@ -85,7 +85,7 @@ fn main() {
     loop {
         accept.try_push_accept(&ring);
 
-        ring.poll_completions();
+        ring.poll_completions(0, 100);
 
         let mut queue = TOKEN_QUEUE.lock().unwrap();
         while !queue.is_empty() {

--- a/src/libos/crates/io-uring-callback/examples/tcp_echo.rs
+++ b/src/libos/crates/io-uring-callback/examples/tcp_echo.rs
@@ -69,10 +69,10 @@ impl AcceptCount {
 }
 
 fn main() {
-    let ring = Builder::new().build(256).unwrap();
-    unsafe {
-        ring.start_enter_syscall_thread();
-    }
+    let ring = Builder::new()
+        .setup_sqpoll(Some(500 /* ms */))
+        .build(256)
+        .unwrap();
     let listener = TcpListener::bind(("127.0.0.1", 3456)).unwrap();
 
     let mut bufpool = Vec::with_capacity(64);

--- a/src/libos/crates/sgx-disk/Cargo.toml
+++ b/src/libos/crates/sgx-disk/Cargo.toml
@@ -26,5 +26,10 @@ sgx_libc = { path = "../../../../deps/rust-sgx-sdk/sgx_libc", optional = true }
 sgx_tcrypto = { path = "../../../../deps/rust-sgx-sdk/sgx_tcrypto", optional = true }
 
 [dev-dependencies]
+async-trait = "0.1.52"
 async-rt = { path = "../async-rt", features = ["auto_run"] }
 lazy_static = { version = "1.4.0", features = ["spin_no_std"] }
+
+[[bench]]
+name = "disk_bench"
+harness = false

--- a/src/libos/crates/sgx-disk/benches/disk_bench.rs
+++ b/src/libos/crates/sgx-disk/benches/disk_bench.rs
@@ -1,0 +1,531 @@
+#![feature(new_uninit)]
+
+use std::time::Instant;
+
+use errno::prelude::{Errno::*, *};
+
+use self::benches::{Bench, BenchBuilder, IoPattern, IoType};
+use self::consts::*;
+use self::tmp_disk::DiskType;
+use self::util::{DisplayData, DisplayThroughput};
+
+fn main() {
+    // Specify the number of threads to execute async tasks
+    async_rt::config::set_parallelism(4);
+
+    // Specify all benchmarks
+    let mut benches = [
+        BenchBuilder::new("sync_io_disk::write_seq")
+            .disk_type(DiskType::SyncIoDisk)
+            .io_type(IoType::Write)
+            .io_pattern(IoPattern::Seq)
+            .total_bytes(1 * GiB)
+            .concurrency(1)
+            .build()
+            .unwrap(),
+        BenchBuilder::new("sync_io_disk::read_seq")
+            .disk_type(DiskType::SyncIoDisk)
+            .io_type(IoType::Read)
+            .io_pattern(IoPattern::Seq)
+            .total_bytes(1 * GiB)
+            .concurrency(1)
+            .build()
+            .unwrap(),
+        BenchBuilder::new("io_uring_disk::write_seq")
+            .disk_type(DiskType::IoUringDisk)
+            .io_type(IoType::Write)
+            .io_pattern(IoPattern::Seq)
+            .total_bytes(1 * GiB)
+            .concurrency(1)
+            .build()
+            .unwrap(),
+        BenchBuilder::new("io_uring_disk::read_seq")
+            .disk_type(DiskType::IoUringDisk)
+            .io_type(IoType::Read)
+            .io_pattern(IoPattern::Seq)
+            .total_bytes(1 * GiB)
+            .concurrency(1)
+            .build()
+            .unwrap(),
+    ];
+
+    // Run all benchmarks and output the results
+    run_benches(&mut benches);
+}
+
+fn run_benches(benches: &mut [Box<dyn Bench>]) {
+    println!("");
+
+    let mut benched_count = 0;
+    let mut failed_count = 0;
+    for b in benches {
+        print!("bench {} ... ", &b);
+        let start = Instant::now();
+        let res = b.run();
+        if let Err(e) = res {
+            failed_count += 1;
+            println!("failed due to error {:?}", e);
+            continue;
+        }
+
+        let end = Instant::now();
+        let elapsed = end - start;
+        let throughput = DisplayThroughput::new(b.total_bytes(), elapsed);
+        println!("{}", throughput);
+        benched_count += 1;
+    }
+
+    let bench_res = if failed_count == 0 { "ok" } else { "failed" };
+    println!(
+        "\nbench result: {}. {} benched; {} failed.",
+        bench_res, benched_count, failed_count
+    );
+}
+
+mod benches {
+    use std::fmt::{self};
+    use std::sync::Arc;
+
+    use super::tmp_disk::{DiskType, TmpDisk};
+    use super::*;
+    use async_rt::task::JoinHandle;
+    use async_trait::async_trait;
+    use block_device::{BlockDevice, BlockDeviceExt, BLOCK_SIZE};
+
+    pub trait Bench: fmt::Display {
+        /// Returns the name of the benchmark.
+        fn name(&self) -> &str;
+
+        /// Returns the total number of bytes read or written.
+        fn total_bytes(&self) -> usize;
+
+        /// Run the benchmark.
+        fn run(&mut self) -> Result<()>;
+    }
+
+    pub struct BenchBuilder {
+        name: String,
+        disk_type: Option<DiskType>,
+        io_type: Option<IoType>,
+        io_pattern: Option<IoPattern>,
+        buf_size: usize,
+        total_bytes: usize,
+        concurrency: u32,
+    }
+
+    impl BenchBuilder {
+        pub fn new(name: &str) -> Self {
+            Self {
+                name: name.to_string(),
+                disk_type: None,
+                io_type: None,
+                io_pattern: None,
+                buf_size: 4 * KiB,
+                total_bytes: 10 * MB,
+                concurrency: 1,
+            }
+        }
+
+        pub fn disk_type(mut self, disk_type: DiskType) -> Self {
+            self.disk_type = Some(disk_type);
+            self
+        }
+
+        pub fn io_type(mut self, io_type: IoType) -> Self {
+            self.io_type = Some(io_type);
+            self
+        }
+
+        pub fn io_pattern(mut self, io_pattern: IoPattern) -> Self {
+            self.io_pattern = Some(io_pattern);
+            self
+        }
+
+        pub fn buf_size(mut self, buf_size: usize) -> Self {
+            self.buf_size = buf_size;
+            self
+        }
+
+        pub fn total_bytes(mut self, total_bytes: usize) -> Self {
+            self.total_bytes = total_bytes;
+            self
+        }
+
+        pub fn concurrency(mut self, concurrency: u32) -> Self {
+            self.concurrency = concurrency;
+            self
+        }
+
+        pub fn build(self) -> Result<Box<dyn Bench>> {
+            let Self {
+                name,
+                disk_type,
+                io_type,
+                io_pattern,
+                buf_size,
+                total_bytes,
+                concurrency,
+            } = self;
+
+            let disk_type = match disk_type {
+                Some(disk_type) => disk_type,
+                None => return Err(errno!(EINVAL, "disk_type is not given")),
+            };
+            let io_type = match io_type {
+                Some(io_type) => io_type,
+                None => return Err(errno!(EINVAL, "io_type is not given")),
+            };
+            let io_pattern = match io_pattern {
+                Some(io_pattern) => io_pattern,
+                None => return Err(errno!(EINVAL, "io_pattern is not given")),
+            };
+            if buf_size == 0 {
+                return Err(errno!(EINVAL, "buf_size must be greater than 0"));
+            }
+            if total_bytes == 0 {
+                return Err(errno!(EINVAL, "total_bytes must be greater than 0"));
+            }
+            if concurrency == 0 {
+                return Err(errno!(EINVAL, "concurrency must be greater than 0"));
+            }
+
+            Ok(Box::new(SimpleDiskBench {
+                name,
+                disk_type,
+                io_type,
+                io_pattern,
+                buf_size,
+                total_bytes,
+                concurrency,
+            }))
+        }
+    }
+
+    pub struct SimpleDiskBench {
+        name: String,
+        disk_type: DiskType,
+        io_type: IoType,
+        io_pattern: IoPattern,
+        buf_size: usize,
+        total_bytes: usize,
+        concurrency: u32,
+    }
+
+    impl Bench for SimpleDiskBench {
+        fn name(&self) -> &str {
+            &self.name
+        }
+
+        fn total_bytes(&self) -> usize {
+            self.total_bytes
+        }
+
+        fn run(&mut self) -> Result<()> {
+            let disk = Arc::new(TmpDisk::create(self.disk_type, self.total_bytes)?);
+            let io_type = self.io_type;
+            let io_pattern = self.io_pattern;
+            let buf_size = self.buf_size;
+            let total_bytes = self.total_bytes;
+            let concurrency = self.concurrency;
+            async_rt::task::block_on(async move {
+                let mut join_handles: Vec<JoinHandle<Result<()>>> = (0..concurrency)
+                    .map(|i| {
+                        let disk = disk.clone();
+                        let local_bytes = total_bytes / (concurrency as usize);
+                        let local_offset = (i as usize) * local_bytes;
+                        async_rt::task::spawn(async move {
+                            match (io_type, io_pattern) {
+                                (IoType::Read, IoPattern::Seq) => {
+                                    disk.read_seq(local_offset, local_bytes, buf_size).await
+                                }
+                                //(IoType::Read, IoPattern::Rnd) => disk.read_rnd(total_bytes, buf_size).await,
+                                (IoType::Write, IoPattern::Seq) => {
+                                    disk.write_seq(local_offset, local_bytes, buf_size).await
+                                }
+                                //(IoType::Write, IoPattern::Rnd) => disk.write_rnd(total_bytes, buf_size).await,
+                                _ => Err(errno!(ENOSYS, "random I/O is not supported yet")),
+                            }
+                        })
+                    })
+                    .collect();
+
+                let mut any_error = None;
+                for (i, join_handle) in join_handles.iter_mut().enumerate() {
+                    let res = join_handle.await;
+                    if let Err(e) = res {
+                        println!("benchmark task error: {:?}", &e);
+                        any_error = Some(e);
+                    }
+                }
+                match any_error {
+                    None => Ok(()),
+                    Some(e) => Err(e),
+                }
+            })
+        }
+    }
+
+    #[async_trait]
+    pub trait BlockDeviceBenchExt {
+        async fn read_seq(&self, offset: usize, total_bytes: usize, buf_size: usize) -> Result<()>;
+        async fn write_seq(&self, offset: usize, total_bytes: usize, buf_size: usize)
+            -> Result<()>;
+    }
+
+    #[async_trait]
+    impl<B: BlockDevice> BlockDeviceBenchExt for B {
+        async fn read_seq(
+            &self,
+            mut offset: usize,
+            total_bytes: usize,
+            buf_size: usize,
+        ) -> Result<()> {
+            let disk_size = self.total_blocks() * BLOCK_SIZE;
+            let mut buf: Box<[u8]> = unsafe { Box::new_uninit_slice(buf_size).assume_init() };
+            let mut remain_bytes = total_bytes;
+            while remain_bytes > 0 {
+                if offset >= disk_size {
+                    offset = 0;
+                }
+
+                let max_read = remain_bytes.min(buf_size).min(disk_size - offset);
+                let read_len = self.read(offset, &mut buf[..max_read]).await?;
+
+                remain_bytes -= read_len;
+                offset += read_len;
+            }
+            Ok(())
+        }
+
+        async fn write_seq(
+            &self,
+            mut offset: usize,
+            total_bytes: usize,
+            buf_size: usize,
+        ) -> Result<()> {
+            let disk_size = self.total_blocks() * BLOCK_SIZE;
+            let buf: Box<[u8]> = unsafe { Box::new_zeroed_slice(buf_size).assume_init() };
+            let mut remain_bytes = total_bytes;
+            while remain_bytes > 0 {
+                if offset >= disk_size {
+                    offset = 0;
+                }
+
+                let max_write = remain_bytes.min(buf_size).min(disk_size - offset);
+                let write_len = self.write(offset, &buf[..max_write]).await?;
+
+                remain_bytes -= write_len;
+                offset += write_len;
+            }
+            self.flush().await?;
+            Ok(())
+        }
+    }
+
+    impl fmt::Display for SimpleDiskBench {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(
+                f,
+                "{} (total = {}, buf = {}, tasks = {})",
+                self.name(),
+                DisplayData::new(self.total_bytes),
+                DisplayData::new(self.buf_size),
+                self.concurrency
+            )
+        }
+    }
+
+    #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+    pub enum IoType {
+        Read,
+        Write,
+    }
+
+    #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+    pub enum IoPattern {
+        Seq,
+        Rnd,
+    }
+}
+
+mod consts {
+    pub const B: usize = 1;
+
+    pub const KiB: usize = 1024 * B;
+    pub const MiB: usize = 1024 * KiB;
+    pub const GiB: usize = 1024 * MiB;
+
+    pub const KB: usize = 1000 * B;
+    pub const MB: usize = 1000 * KB;
+    pub const GB: usize = 1000 * MB;
+}
+
+mod tmp_disk {
+    use std::sync::Arc;
+
+    use block_device::{BioReq, BioSubmission, BlockDevice, BlockDeviceExt, BLOCK_SIZE};
+    use sgx_disk::{HostDisk, IoUringDisk, SyncIoDisk};
+
+    use self::io_uring_rt::IoUringSingleton;
+    use super::util::align_up;
+    use super::*;
+
+    #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+    pub enum DiskType {
+        SyncIoDisk,
+        IoUringDisk,
+    }
+
+    pub struct TmpDisk {
+        file_path: String,
+        inner_disk: Box<dyn BlockDevice>,
+    }
+
+    impl TmpDisk {
+        pub fn create(disk_type: DiskType, total_bytes: usize) -> Result<Self> {
+            let file_path = Self::gen_tmp_path();
+            let total_blocks = align_up(total_bytes, BLOCK_SIZE) / BLOCK_SIZE;
+            let inner_disk: Box<dyn BlockDevice> = match disk_type {
+                DiskType::SyncIoDisk => Box::new(SyncIoDisk::create(&file_path, total_blocks)?),
+                DiskType::IoUringDisk => Box::new(IoUringDisk::<IoUringSingleton>::create(
+                    &file_path,
+                    total_blocks,
+                )?),
+            };
+            let tmp_disk = Self {
+                file_path,
+                inner_disk,
+            };
+            Ok(tmp_disk)
+        }
+
+        fn gen_tmp_path() -> String {
+            use std::sync::atomic::{AtomicU32, Ordering::Relaxed};
+            static NEXT_ID: AtomicU32 = AtomicU32::new(0);
+            let id = NEXT_ID.fetch_add(1, Relaxed);
+            format!("disk{}.image", id)
+        }
+    }
+
+    impl BlockDevice for TmpDisk {
+        fn total_blocks(&self) -> usize {
+            self.inner_disk.total_blocks()
+        }
+
+        fn submit(&self, req: Arc<BioReq>) -> BioSubmission {
+            self.inner_disk.submit(req)
+        }
+    }
+
+    impl Drop for TmpDisk {
+        fn drop(&mut self) {
+            std::fs::remove_file(&self.file_path);
+        }
+    }
+
+    mod io_uring_rt {
+        use super::*;
+        use io_uring_callback::{Builder, IoUring};
+        use lazy_static::lazy_static;
+        use sgx_disk::IoUringProvider;
+
+        pub struct IoUringSingleton;
+
+        impl IoUringProvider for IoUringSingleton {
+            fn io_uring() -> &'static IoUring {
+                &*IO_URING
+            }
+        }
+
+        lazy_static! {
+            static ref IO_URING: Arc<IoUring> = {
+                let ring = Arc::new(Builder::new().build(256).unwrap());
+                unsafe {
+                    ring.start_enter_syscall_thread();
+                }
+                async_rt::task::spawn({
+                    let ring = ring.clone();
+                    async move {
+                        loop {
+                            ring.poll_completions();
+                            async_rt::sched::yield_().await;
+                        }
+                    }
+                });
+                ring
+            };
+        }
+    }
+}
+
+mod util {
+    use super::*;
+    use std::fmt::{self};
+    use std::time::Duration;
+
+    pub fn align_up(n: usize, a: usize) -> usize {
+        debug_assert!(a >= 2 && a.is_power_of_two());
+        (n + a - 1) & !(a - 1)
+    }
+
+    /// Display the amount of data in the unit of GB, MB, KB, or bytes.
+    #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+    pub struct DisplayData(usize);
+
+    impl DisplayData {
+        pub fn new(nbytes: usize) -> Self {
+            Self(nbytes)
+        }
+    }
+
+    impl fmt::Display for DisplayData {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            const UNIT_TABLE: [(&str, usize); 4] =
+                [("GiB", GiB), ("MiB", MiB), ("KiB", KiB), ("bytes", 0)];
+            let (unit_str, unit_val) = {
+                let (unit_str, mut unit_val) = UNIT_TABLE
+                    .iter()
+                    .find(|(_, unit_val)| self.0 >= *unit_val)
+                    .unwrap();
+                if unit_val == 0 {
+                    unit_val = 1;
+                }
+                (unit_str, unit_val)
+            };
+            let data_val_in_unit = (self.0 as f64) / (unit_val as f64);
+            write!(f, "{:.1} {}", data_val_in_unit, unit_str)
+        }
+    }
+
+    /// Display throughput in the unit of bytes/s, KB/s, MB/s, or GB/s.
+    #[derive(Copy, Clone, Debug, PartialEq)]
+    pub struct DisplayThroughput(f64);
+
+    impl DisplayThroughput {
+        pub fn new(total_bytes: usize, elapsed: Duration) -> Self {
+            let total_bytes = total_bytes as f64;
+            let elapsed_secs = elapsed.as_secs_f64();
+            let throughput = total_bytes / elapsed_secs;
+            Self(throughput)
+        }
+    }
+
+    impl fmt::Display for DisplayThroughput {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            const UNIT_TABLE: [(&str, usize); 4] =
+                [("GB/s", GB), ("MB/s", MB), ("KB/s", KB), ("bytes/s", 0)];
+            let (unit_str, unit_val) = {
+                let (unit_str, mut unit_val) = UNIT_TABLE
+                    .iter()
+                    .find(|(_, unit_val)| self.0 >= (*unit_val as f64))
+                    .unwrap();
+                if unit_val == 0 {
+                    unit_val = 1;
+                }
+                (unit_str, unit_val)
+            };
+            let throughput_in_unit = self.0 / (unit_val as f64);
+            write!(f, "{:.1} {}", throughput_in_unit, unit_str)
+        }
+    }
+}

--- a/src/libos/crates/sgx-disk/src/host_disk/io_uring_disk.rs
+++ b/src/libos/crates/sgx-disk/src/host_disk/io_uring_disk.rs
@@ -447,13 +447,12 @@ mod test {
                 unsafe {
                     ring.start_enter_syscall_thread();
                 }
-                async_rt::task::spawn({
+                std::thread::spawn({
                     let ring = ring.clone();
-                    async move {
-                        loop {
-                            ring.poll_completions();
-                            async_rt::sched::yield_().await;
-                        }
+                    move || loop {
+                        let min_complete = 1;
+                        let polling_retries = 10000;
+                        ring.poll_completions(min_complete, polling_retries);
                     }
                 });
                 ring

--- a/src/libos/crates/sgx-disk/src/host_disk/io_uring_disk.rs
+++ b/src/libos/crates/sgx-disk/src/host_disk/io_uring_disk.rs
@@ -443,10 +443,11 @@ mod test {
 
         lazy_static! {
             static ref IO_URING: Arc<IoUring> = {
-                let ring = Arc::new(Builder::new().build(256).unwrap());
-                unsafe {
-                    ring.start_enter_syscall_thread();
-                }
+                let ring = Arc::new(
+                    Builder::new()
+                        .setup_sqpoll(Some(500/* ms */))
+                        .build(256)
+                        .unwrap());
                 std::thread::spawn({
                     let ring = ring.clone();
                     move || loop {

--- a/src/libos/src/fs/builtin_disk.rs
+++ b/src/libos/src/fs/builtin_disk.rs
@@ -15,78 +15,59 @@ pub fn try_open_disk(fs: &FsView, fs_path: &FsPath) -> Result<Option<Arc<DiskFil
         return Ok(None);
     }
 
-    let abs_path = PathBuf::from(abs_path);
-    if let Some(lazy_disk) = BUILTIN_DISKS.get(&abs_path) {
-        let disk: Arc<dyn BlockDevice> = lazy_disk.deref().clone();
-        let disk_file = Arc::new(DiskFile::new(disk));
-        Ok(Some(disk_file))
-    } else {
-        Ok(None)
-    }
-}
-
-lazy_static! {
-    static ref BUILTIN_DISKS: HashMap<PathBuf, LazyDisk> = {
-        fn new_disk_entry<F>(
-            name: &str,
-            disk_size: usize,
-            new_disk_fn: F,
-        ) -> (PathBuf, LazyDisk)
-            where F: Fn(/*file_path:*/ &str, /*total_blocks:*/ usize) -> Arc<dyn BlockDevice> + Send + 'static
-        {
-            let name = name.to_string();
-            let dev_path = PathBuf::from(format!("/dev/{}", &name));
-            let lazy_disk: LazyDisk = Lazy::new(Box::new(move || {
-                let total_blocks = to_blocks(disk_size);
-                let file_path = format!("{}.image", name);
-                (new_disk_fn)(&file_path, total_blocks)
-            }));
-            (dev_path, lazy_disk)
+    let disk: Arc<dyn BlockDevice> = match abs_path.as_str() {
+        "/dev/mem_disk" => {
+            let total_blocks = 32 * MB / BLOCK_SIZE;
+            let mem_disk = MemDisk::new(total_blocks)?;
+            Arc::new(mem_disk)
         }
-
-        let disk_entries = vec![
-            new_disk_entry("mem_disk", 32*MB, |_, total_blocks| {
-                let mem_disk = MemDisk::new(total_blocks).unwrap();
-                Arc::new(mem_disk)
-            }),
-            new_disk_entry("sync_disk", 2*GB, |file_path, total_blocks| {
-                let disk = SyncIoDisk::create(file_path, total_blocks).unwrap();
-                Arc::new(disk)
-            }),
-            new_disk_entry("iou_disk", 2*GB, |file_path, total_blocks| {
-                let disk = IoUringDisk::<IoUringRuntime>::create(file_path, total_blocks).unwrap();
-                Arc::new(disk)
-            }),
-            new_disk_entry("crypt_sync_disk", 2*GB, |file_path, total_blocks| {
-                let sync_disk = SyncIoDisk::create(file_path, total_blocks).unwrap();
-                let crypt_disk = CryptDisk::new(Box::new(sync_disk));
-                Arc::new(crypt_disk)
-            }),
-            new_disk_entry("crypt_iou_disk", 2*GB, |file_path, total_blocks| {
-                let iou_disk = IoUringDisk::<IoUringRuntime>::create(file_path, total_blocks).unwrap();
-                let crypt_disk = CryptDisk::new(Box::new(iou_disk));
-                Arc::new(crypt_disk)
-            }),
-            new_disk_entry("pfs_disk", 2*GB, |file_path, total_blocks| {
-                let disk = PfsDisk::create(file_path, total_blocks).unwrap();
-                Arc::new(disk)
-            }),
-        ];
-        let builtin_disks: HashMap<PathBuf, LazyDisk> = disk_entries
-            .into_iter()
-            .collect();
-        builtin_disks
+        "/dev/sync_disk" => {
+            let file_path = "run/sync_disk.image";
+            let total_blocks = 2 * GB / BLOCK_SIZE;
+            let disk = SyncIoDisk::open(file_path)
+                .or_else(|_| SyncIoDisk::create(file_path, total_blocks))?;
+            Arc::new(disk)
+        }
+        "/dev/iou_disk" => {
+            let file_path = "run/iou_disk.image";
+            let total_blocks = 2 * GB / BLOCK_SIZE;
+            let disk = IoUringDisk::<IoUringRuntime>::open(file_path)
+                .or_else(|_| IoUringDisk::create(file_path, total_blocks))?;
+            Arc::new(disk)
+        }
+        "/dev/crypt_sync_disk" => {
+            let file_path = "run/crypt_sync_disk.image";
+            let total_blocks = 2 * GB / BLOCK_SIZE;
+            let disk = SyncIoDisk::open(file_path)
+                .or_else(|_| SyncIoDisk::create(file_path, total_blocks))?;
+            let crypt_disk = CryptDisk::new(Box::new(disk));
+            Arc::new(crypt_disk)
+        }
+        "/dev/crypt_iou_disk" => {
+            let file_path = "run/crypt_iou_disk.image";
+            let total_blocks = 2 * GB / BLOCK_SIZE;
+            let disk = IoUringDisk::<IoUringRuntime>::open(file_path)
+                .or_else(|_| IoUringDisk::create(file_path, total_blocks))?;
+            let crypt_disk = CryptDisk::new(Box::new(disk));
+            Arc::new(crypt_disk)
+        }
+        "/dev/pfs_disk" => {
+            let file_path = "run/pfs_disk.image";
+            let total_blocks = 2 * GB / BLOCK_SIZE;
+            let disk =
+                PfsDisk::open(file_path).or_else(|_| PfsDisk::create(file_path, total_blocks))?;
+            Arc::new(disk)
+        }
+        _ => {
+            return Ok(None);
+        }
     };
+    let disk_file = Arc::new(DiskFile::new(disk));
+    Ok(Some(disk_file))
 }
-
-type LazyDisk = Lazy<Arc<dyn BlockDevice>, Box<dyn FnOnce() -> Arc<dyn BlockDevice> + Send>>;
 
 const MB: usize = 1024 * 1024;
 const GB: usize = 1024 * 1024 * 1024;
-
-fn to_blocks(size_in_bytes: usize) -> usize {
-    align_up(size_in_bytes, BLOCK_SIZE) / BLOCK_SIZE
-}
 
 mod runtime {
     use io_uring_callback::IoUring;

--- a/src/libos/src/fs/file_ops/close.rs
+++ b/src/libos/src/fs/file_ops/close.rs
@@ -1,8 +1,24 @@
 use super::*;
 
-pub fn do_close(fd: FileDesc) -> Result<()> {
+pub async fn do_close(fd: FileDesc) -> Result<()> {
     debug!("close: fd: {}", fd);
     let current = current!();
+
+    // Make sure the writes of disk files persist.
+    //
+    // Currently, disk files are the only types of files
+    // that may have internal caches for updates and
+    // requires explict flushes to ensure the persist of the
+    // updates.
+    //
+    // TODO: add a general-purpose mechanism to do async drop.
+    // If we can support async drop, then there is no need to
+    // do explicit cleanup/shutdown/flush when closing fd.
+    let file_ref = current!().file(fd)?;
+    if let Some(disk_file) = file_ref.as_disk_file() {
+        let _ = disk_file.flush().await;
+    }
+
     current.close_file(fd)?;
     Ok(())
 }

--- a/src/libos/src/fs/syscalls.rs
+++ b/src/libos/src/fs/syscalls.rs
@@ -61,7 +61,7 @@ pub async fn do_umask(mask: u16) -> Result<isize> {
 }
 
 pub async fn do_close(fd: FileDesc) -> Result<isize> {
-    file_ops::do_close(fd)?;
+    file_ops::do_close(fd).await?;
     Ok(0)
 }
 

--- a/src/libos/src/io_uring.rs
+++ b/src/libos/src/io_uring.rs
@@ -2,10 +2,10 @@ use io_uring_callback::{Builder, IoUring};
 
 lazy_static::lazy_static! {
     pub static ref SINGLETON: IoUring = {
-        let io_uring = Builder::new().build(256).unwrap();
-        unsafe {
-            io_uring.start_enter_syscall_thread();
-        }
+        let io_uring = Builder::new()
+            .setup_sqpoll(Some(500/* ms */))
+            .build(256)
+            .unwrap();
         io_uring
     };
 }


### PR DESCRIPTION
This PR is intended to identify and fix performance issues regarding the async runtime, async I/O, io_uring, and block devices.

As the first steps, this PR adds a series of benchmarks. Here are some of the results.
* Benchmark results of `async_rt` primitives
![image](https://user-images.githubusercontent.com/568208/172076569-5f512222-be37-4af2-ad13-3905e4fc8eae.png)
* Benchmark results of `Channel<u8>` in `async_io`
![image](https://user-images.githubusercontent.com/568208/172076636-dfa0174c-4763-4eda-bac5-66cc570d87bd.png)
* Benchmark results of several types of disks in `sgx-disk`
![image](https://user-images.githubusercontent.com/568208/172076687-75f78b29-8ef6-40ca-98df-1746064cb123.png)

Based on the observations acquired from the benchmarks, this PR fixes several performance issues in async_rt and io_uring_callack.
* [[async-rt] Fix the premature sleep of the executor](https://github.com/tatetian/ngo/commit/6e28598693cd9d84f493d41492cde3a00323634b)
* [[io-uring-callback] Improve the efficiency of completion polling](https://github.com/tatetian/ngo/commit/7297664b245ed7c7965e1f74777d1c6b92a40a67)
* [[io-uring-callback] Enable kernel polling mode](https://github.com/tatetian/ngo/commit/cb4b5dcf1a987d4ed28aa6df6081de0b70eee2a6)

