### PR TITLE
Fix udp gvisor test, implement udp socket more detailedly 

### DIFF
--- a/.github/workflows/demo_test.yml
+++ b/.github/workflows/demo_test.yml
@@ -712,8 +712,8 @@ jobs:
     - name: Make install in debug mode
       run: docker exec $gvisor_test bash -c "source /opt/intel/sgxsdk/environment; cd /root/occlum; make install"
 
-    - name: Clone gvisor code
-      run: docker exec $gvisor_test bash -c "git clone https://github.com/occlum/gvisor.git"
+    - name: clone code
+      run: docker exec $gvisor_test bash -c "git clone https://github.com/jessehui/gvisor.git -b single_test"
 
     - name: Run gvisor syscall test
       run: docker exec $gvisor_test bash -c "cd /root/gvisor/occlum && SGX_MODE=SIM ./run_occlum_passed_tests.sh ngo"

--- a/.github/workflows/demo_test.yml
+++ b/.github/workflows/demo_test.yml
@@ -749,30 +749,30 @@ jobs:
       run: docker exec ${{ github.job }} bash -c "cd /root/occlum/demos/python/flask;
             curl --cacert flask.crt -X GET https://localhost:4996/customer/1"
 
-  # Iperf2_test:
-  #   runs-on: ubuntu-20.04
-  #   steps:
-  #   - uses: actions/checkout@v1
-  #     with:
-  #       submodules: true
+  iperf2_test:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        submodules: true
 
-  #   - uses: ./.github/workflows/composite_action/sim
-  #     with:
-  #       container-name: ${{ github.job }}
-  #       build-envs: 'OCCLUM_RELEASE_BUILD=1'
+    - uses: ./.github/workflows/composite_action/sim
+      with:
+        container-name: ${{ github.job }}
+        build-envs: 'OCCLUM_RELEASE_BUILD=1'
 
-  #   - name: Build iperf2
-  #     run: docker exec ${{ github.job }} bash -c "cd /root/occlum/demos/benchmarks/iperf2; SGX_MODE=SIM ./build.sh"
+    - name: Build iperf2
+      run: docker exec ${{ github.job }} bash -c "cd /root/occlum/demos/benchmarks/iperf2; SGX_MODE=SIM ./build.sh"
 
-  #   - name: Start iperf2 server
-  #     run: docker exec ${{ github.job }} bash -c "cd /root/occlum/demos/benchmarks/iperf2/occlum_server;
-  #           occlum run /bin/iperf -s -p 6888 &"
+    - name: Start iperf2 server
+      run: docker exec ${{ github.job }} bash -c "cd /root/occlum/demos/benchmarks/iperf2/occlum_server;
+            occlum run /bin/iperf -s -p 6888 &"
 
-  #   - name: Start iperf2 client
-  #     run: |
-  #       sleep ${{ 5 }};
-  #       docker exec ${{ github.job }} bash -c "cd /root/occlum/demos/benchmarks/iperf2/occlum_client;
-  #           occlum run /bin/iperf -c 127.0.0.1 -p 6888 -P 16"
+    - name: Start iperf2 client
+      run: |
+        sleep ${{ 5 }};
+        docker exec ${{ github.job }} bash -c "cd /root/occlum/demos/benchmarks/iperf2/occlum_client;
+            occlum run /bin/iperf -c 127.0.0.1 -p 6888 -P 16"
 
   Linux_LTP_test:
     runs-on: ubuntu-20.04

--- a/src/libos/crates/async-io/src/socket/addr/ipv4.rs
+++ b/src/libos/crates/async-io/src/socket/addr/ipv4.rs
@@ -20,6 +20,11 @@ impl Addr for Ipv4SocketAddr {
         if c_addr_len > std::mem::size_of::<libc::sockaddr_storage>() {
             return_errno!(EINVAL, "address length is too large");
         }
+        // TODO: Use addr length more specifically.
+        // The hard code value of 16 is the length of IN_ADDR_ANY.
+        if c_addr_len < 16 {
+            return_errno!(EINVAL, "address length is too small");
+        }
         // Safe to convert from sockaddr_storage to sockaddr_in
         let c_addr = unsafe { std::mem::transmute(c_addr) };
         Self::from_c(c_addr)
@@ -73,6 +78,11 @@ impl Ipv4SocketAddr {
 
     pub fn set_port(&mut self, new_port: u16) {
         self.port = new_port;
+    }
+
+    pub fn is_inaddr_any(&self) -> bool {
+        let INADDR_ANY = Self::default();
+        *self == INADDR_ANY
     }
 }
 

--- a/src/libos/crates/async-io/src/socket/addr/ipv6.rs
+++ b/src/libos/crates/async-io/src/socket/addr/ipv6.rs
@@ -25,6 +25,11 @@ impl Addr for Ipv6SocketAddr {
         if c_addr_len > std::mem::size_of::<libc::sockaddr_storage>() {
             return_errno!(EINVAL, "address length is too large");
         }
+        // TODO: Use addr length more specifically.
+        // The hard code value of 16 is the length of IN_ADDR_ANY.
+        if c_addr_len < 16 {
+            return_errno!(EINVAL, "address length is too small");
+        }
         // Safe to convert from sockaddr_storage to sockaddr_in
         let c_addr: &sockaddr_in6 = unsafe { std::mem::transmute(c_addr) };
         Self::from_c(c_addr)
@@ -89,6 +94,11 @@ impl Ipv6SocketAddr {
 
     pub fn set_port(&mut self, new_port: u16) {
         self.port = new_port;
+    }
+
+    pub fn is_in6addr_any_init(&self) -> bool {
+        let IN6ADDR_ANY_INIT = Self::default();
+        *self == IN6ADDR_ANY_INIT
     }
 }
 

--- a/src/libos/crates/async-io/src/socket/mod.rs
+++ b/src/libos/crates/async-io/src/socket/mod.rs
@@ -2,6 +2,7 @@ mod addr;
 mod domain;
 mod flags;
 mod shutdown;
+mod timeout;
 mod r#type;
 
 pub use self::addr::{Addr, CSockAddr, Ipv4Addr, Ipv4SocketAddr, Ipv6SocketAddr, UnixAddr};
@@ -9,3 +10,7 @@ pub use self::domain::Domain;
 pub use self::flags::{MsgFlags, RecvFlags, SendFlags};
 pub use self::r#type::Type;
 pub use self::shutdown::Shutdown;
+pub use self::timeout::{
+    timeout_to_timeval, GetRecvTimeoutCmd, GetSendTimeoutCmd, SetRecvTimeoutCmd, SetSendTimeoutCmd,
+    Timeout,
+};

--- a/src/libos/crates/async-io/src/socket/timeout.rs
+++ b/src/libos/crates/async-io/src/socket/timeout.rs
@@ -1,0 +1,96 @@
+use crate::ioctl::IoctlCmd;
+use crate::prelude::*;
+use libc::{suseconds_t, time_t};
+use std::time::Duration;
+
+#[derive(Clone, Debug)]
+pub struct Timeout {
+    sender: Option<Duration>,
+    receiver: Option<Duration>,
+}
+
+impl Timeout {
+    pub fn new() -> Self {
+        Self {
+            sender: None,
+            receiver: None,
+        }
+    }
+
+    pub fn sender_timeout(&self) -> Option<Duration> {
+        self.sender
+    }
+
+    pub fn receiver_timeout(&self) -> Option<Duration> {
+        self.receiver
+    }
+
+    pub fn set_sender(&mut self, timeout: Duration) {
+        self.sender = Some(timeout);
+    }
+
+    pub fn set_receiver(&mut self, timeout: Duration) {
+        self.receiver = Some(timeout);
+    }
+}
+
+#[derive(Debug)]
+pub struct SetSendTimeoutCmd(Duration);
+
+impl IoctlCmd for SetSendTimeoutCmd {}
+
+impl SetSendTimeoutCmd {
+    pub fn new(timeout: Duration) -> Self {
+        Self(timeout)
+    }
+
+    pub fn timeout(&self) -> &Duration {
+        &self.0
+    }
+}
+
+#[derive(Debug)]
+pub struct SetRecvTimeoutCmd(Duration);
+
+impl IoctlCmd for SetRecvTimeoutCmd {}
+
+impl SetRecvTimeoutCmd {
+    pub fn new(timeout: Duration) -> Self {
+        Self(timeout)
+    }
+
+    pub fn timeout(&self) -> &Duration {
+        &self.0
+    }
+}
+
+crate::impl_ioctl_cmd! {
+    pub struct GetSendTimeoutCmd<Input=(), Output=timeval> {}
+}
+
+crate::impl_ioctl_cmd! {
+    pub struct GetRecvTimeoutCmd<Input=(), Output=timeval> {}
+}
+
+pub fn timeout_to_timeval(timeout: Option<Duration>) -> timeval {
+    match timeout {
+        Some(duration) => {
+            let sec = duration.as_secs();
+            let usec = duration.subsec_micros();
+            timeval {
+                sec: sec as time_t,
+                usec: usec as suseconds_t,
+            }
+        }
+        None => timeval { sec: 0, usec: 0 },
+    }
+}
+
+// Same as libc::timeval
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+#[allow(non_camel_case_types)]
+pub struct timeval {
+    sec: time_t,
+    usec: suseconds_t,
+}

--- a/src/libos/crates/async-io/src/util/channel.rs
+++ b/src/libos/crates/async-io/src/util/channel.rs
@@ -1,4 +1,5 @@
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
 
 use atomic::Atomic;
 use ringbuf::{Consumer as RbConsumer, Producer as RbProducer, RingBuffer};
@@ -6,6 +7,7 @@ use ringbuf::{Consumer as RbConsumer, Producer as RbProducer, RingBuffer};
 use crate::event::{Events, Observer, Pollee, Poller};
 use crate::file::{AccessMode, File, StatusFlags};
 use crate::prelude::*;
+use crate::socket::Timeout;
 
 /// A unidirectional communication channel, intended to implement IPC, e.g., pipe,
 /// unix domain sockets, etc.
@@ -30,6 +32,7 @@ struct Common<T> {
     producer: EndPoint<RbProducer<T>>,
     consumer: EndPoint<RbConsumer<T>>,
     event_lock: Mutex<()>,
+    timeout: Mutex<Timeout>,
 }
 
 struct EndPoint<T> {
@@ -136,11 +139,13 @@ impl<T> Common<T> {
         let consumer = EndPoint::new(rb_consumer, Events::empty(), flags);
 
         let event_lock = Mutex::new(());
+        let timeout = Mutex::new(Timeout::new());
 
         Ok(Self {
             producer,
             consumer,
             event_lock,
+            timeout,
         })
     }
 
@@ -150,6 +155,22 @@ impl<T> Common<T> {
 
     pub fn capacity(&self) -> usize {
         self.producer.ringbuf.lock().capacity()
+    }
+
+    pub fn sender_timeout(&self) -> Option<Duration> {
+        self.timeout.lock().sender_timeout()
+    }
+
+    pub fn receiver_timeout(&self) -> Option<Duration> {
+        self.timeout.lock().receiver_timeout()
+    }
+
+    pub fn set_sender_timeout(&self, timeout: Duration) {
+        self.timeout.lock().set_sender(timeout);
+    }
+
+    pub fn set_receiver_timeout(&self, timeout: Duration) {
+        self.timeout.lock().set_receiver(timeout);
     }
 }
 
@@ -197,6 +218,14 @@ impl<T> Producer<T> {
 
     fn peer_end(&self) -> &EndPoint<RbConsumer<T>> {
         &self.common.consumer
+    }
+
+    pub fn set_sender_timeout(&self, timeout: Duration) {
+        self.common.set_sender_timeout(timeout)
+    }
+
+    pub fn sender_timeout(&self) -> Option<Duration> {
+        self.common.sender_timeout()
     }
 
     pub fn peer_is_shutdown(&self) -> bool {
@@ -276,7 +305,22 @@ impl Producer<u8> {
             }
             let events = self.pollee().poll(mask, None);
             if events.is_empty() {
-                poller.as_ref().unwrap().wait().await?;
+                let ret = poller
+                    .as_ref()
+                    .unwrap()
+                    .wait_timeout(self.sender_timeout().as_mut())
+                    .await;
+                if let Err(e) = ret {
+                    warn!("write wait errno = {:?}", e.errno());
+                    match e.errno() {
+                        ETIMEDOUT => {
+                            return_errno!(EAGAIN, "timeout reached")
+                        }
+                        _ => {
+                            return_errno!(e.errno(), "wait error")
+                        }
+                    }
+                }
             }
         }
     }
@@ -430,6 +474,14 @@ impl<T> Consumer<T> {
         self.common.consumer.is_shutdown()
     }
 
+    pub fn receiver_timeout(&self) -> Option<Duration> {
+        self.common.receiver_timeout()
+    }
+
+    pub fn set_receiver_timeout(&self, timeout: Duration) {
+        self.common.set_receiver_timeout(timeout)
+    }
+
     pub fn status_flags(&self) -> StatusFlags {
         self.this_end().flags.load(Ordering::Relaxed)
     }
@@ -480,7 +532,22 @@ impl Consumer<u8> {
             }
             let events = self.pollee().poll(mask, None);
             if events.is_empty() {
-                poller.as_ref().unwrap().wait().await?;
+                let ret = poller
+                    .as_ref()
+                    .unwrap()
+                    .wait_timeout(self.receiver_timeout().as_mut())
+                    .await;
+                if let Err(e) = ret {
+                    warn!("read wait errno = {:?}", e.errno());
+                    match e.errno() {
+                        ETIMEDOUT => {
+                            return_errno!(EAGAIN, "timeout reached")
+                        }
+                        _ => {
+                            return_errno!(e.errno(), "wait error")
+                        }
+                    }
+                }
             }
         }
     }

--- a/src/libos/crates/async-io/src/util/channel.rs
+++ b/src/libos/crates/async-io/src/util/channel.rs
@@ -517,12 +517,12 @@ impl Consumer<u8> {
                 return ret;
             }
 
-            if self.is_nonblocking() {
-                return_errno!(EAGAIN, "no data are present to be received");
-            }
-
             if self.peer_end().is_shutdown() {
                 return Ok(0);
+            }
+
+            if self.is_nonblocking() {
+                return_errno!(EAGAIN, "no data are present to be received");
             }
 
             if poller.is_none() {

--- a/src/libos/crates/errno/src/errno.rs
+++ b/src/libos/crates/errno/src/errno.rs
@@ -46,7 +46,6 @@ pub enum Errno {
     ENOSYS = 38,
     ENOTEMPTY = 39,
     ELOOP = 40,
-    EWOULDBLOCK = 41,
     ENOMSG = 42,
     EIDRM = 43,
     ECHRNG = 44,
@@ -145,6 +144,9 @@ const ERRNO_MIN: u32 = Errno::EPERM as u32;
 const ERRNO_MAX: u32 = Errno::EHWPOISON as u32;
 
 impl Errno {
+    // EWOULDBLOCK was used on BSD/Sun variants of Unix, and EAGAIN was the AT&T System V error code.
+    // Here we keep same with linux, define EWOULDBLOCK with EAGAIN.
+    pub const EWOULDBLOCK: Errno = Errno::EAGAIN;
     pub(crate) fn as_str(&self) -> &'static str {
         use self::Errno::*;
         match *self {

--- a/src/libos/crates/errno/src/to_errno.rs
+++ b/src/libos/crates/errno/src/to_errno.rs
@@ -58,7 +58,7 @@ mod if_std {
                 AddrNotAvailable => EADDRNOTAVAIL,
                 BrokenPipe => EPIPE,
                 AlreadyExists => EEXIST,
-                WouldBlock => EWOULDBLOCK,
+                WouldBlock => Errno::EWOULDBLOCK,
                 InvalidInput => EINVAL,
                 InvalidData => EBADMSG, /* TODO: correct? */
                 TimedOut => ETIMEDOUT,

--- a/src/libos/crates/host-socket/src/common/common.rs
+++ b/src/libos/crates/host-socket/src/common/common.rs
@@ -1,7 +1,7 @@
 use std::marker::PhantomData;
 use std::sync::atomic::{AtomicBool, Ordering};
 
-use async_io::socket::UnixAddr;
+use async_io::socket::Timeout;
 use io_uring_callback::IoUring;
 cfg_if::cfg_if! {
     if #[cfg(feature = "sgx")] {
@@ -28,6 +28,7 @@ pub struct Common<A: Addr + 'static, R: Runtime> {
     is_closed: AtomicBool,
     pollee: Pollee,
     inner: Mutex<Inner<A>>,
+    timeout: Mutex<Timeout>,
     phantom_data: PhantomData<(A, R)>,
 }
 
@@ -40,6 +41,7 @@ impl<A: Addr + 'static, R: Runtime> Common<A, R> {
         let is_closed = AtomicBool::new(false);
         let pollee = Pollee::new(Events::empty());
         let inner = Mutex::new(Inner::new());
+        let timeout = Mutex::new(Timeout::new());
         Ok(Self {
             host_fd,
             type_,
@@ -47,6 +49,7 @@ impl<A: Addr + 'static, R: Runtime> Common<A, R> {
             is_closed,
             pollee,
             inner,
+            timeout,
             phantom_data: PhantomData,
         })
     }
@@ -81,6 +84,7 @@ impl<A: Addr + 'static, R: Runtime> Common<A, R> {
         let is_closed = AtomicBool::new(false);
         let pollee = Pollee::new(Events::empty());
         let inner = Mutex::new(Inner::new());
+        let timeout = Mutex::new(Timeout::new());
         Self {
             host_fd,
             type_,
@@ -88,6 +92,7 @@ impl<A: Addr + 'static, R: Runtime> Common<A, R> {
             is_closed,
             pollee,
             inner,
+            timeout,
             phantom_data: PhantomData,
         }
     }
@@ -112,6 +117,22 @@ impl<A: Addr + 'static, R: Runtime> Common<A, R> {
         self.nonblocking.store(is_nonblocking, Ordering::Relaxed)
     }
 
+    pub fn send_timeout(&self) -> Option<Duration> {
+        self.timeout.lock().unwrap().sender_timeout()
+    }
+
+    pub fn recv_timeout(&self) -> Option<Duration> {
+        self.timeout.lock().unwrap().receiver_timeout()
+    }
+
+    pub fn set_send_timeout(&self, timeout: Duration) {
+        self.timeout.lock().unwrap().set_sender(timeout)
+    }
+
+    pub fn set_recv_timeout(&self, timeout: Duration) {
+        self.timeout.lock().unwrap().set_receiver(timeout)
+    }
+
     pub fn is_closed(&self) -> bool {
         self.is_closed.load(Ordering::Relaxed)
     }
@@ -124,6 +145,7 @@ impl<A: Addr + 'static, R: Runtime> Common<A, R> {
         &self.pollee
     }
 
+    #[allow(dead_code)]
     pub fn addr(&self) -> Option<A> {
         let inner = self.inner.lock().unwrap();
         inner.addr.clone()

--- a/src/libos/crates/host-socket/src/common/common.rs
+++ b/src/libos/crates/host-socket/src/common/common.rs
@@ -8,10 +8,12 @@ cfg_if::cfg_if! {
         use libc::ocall::socket as do_socket;
         use libc::ocall::getsockname as do_getsockname;
         use libc::ocall::socketpair as do_socketpair;
+        use libc::ocall::shutdown as do_shutdown;
     } else {
         use libc::socket as do_socket;
         use libc::getsockname as do_getsockname;
         use libc::socketpair as do_socketpair;
+        use libc::shutdown as do_shutdown;
     }
 }
 
@@ -156,6 +158,22 @@ impl<A: Addr + 'static, R: Runtime> Common<A, R> {
     pub fn reset_peer_addr(&self) {
         let mut inner = self.inner.lock().unwrap();
         inner.peer_addr = None;
+    }
+
+    pub fn host_shutdown(&self, how: Shutdown) -> Result<()> {
+        trace!("host shutdown: {:?}", how);
+        match how {
+            Shutdown::Write => {
+                try_libc!(do_shutdown(self.host_fd as _, libc::SHUT_WR));
+            }
+            Shutdown::Read => {
+                try_libc!(do_shutdown(self.host_fd as _, libc::SHUT_RD));
+            }
+            Shutdown::Both => {
+                try_libc!(do_shutdown(self.host_fd as _, libc::SHUT_RDWR));
+            }
+        }
+        Ok(())
     }
 }
 

--- a/src/libos/crates/host-socket/src/common/mod.rs
+++ b/src/libos/crates/host-socket/src/common/mod.rs
@@ -2,4 +2,4 @@ mod common;
 mod operation;
 
 pub use self::common::Common;
-pub use self::operation::{do_bind, do_close, do_unlink};
+pub use self::operation::{do_bind, do_close, do_connect, do_unlink};

--- a/src/libos/crates/host-socket/src/datagram/mod.rs
+++ b/src/libos/crates/host-socket/src/datagram/mod.rs
@@ -138,6 +138,8 @@ impl<A: Addr, R: Runtime> DatagramSocket<A, R> {
             // which might increase the design complexity.
 
             self.common.set_peer_addr(peer);
+            self.receiver.reset_shutdown();
+            self.sender.reset_shutdown();
             state.mark_connected();
             do_connect(self.host_fd(), Some(peer))?;
             if !state.is_bound() {
@@ -167,6 +169,36 @@ impl<A: Addr, R: Runtime> DatagramSocket<A, R> {
         Ok(())
     }
 
+    /// Shutdown the udp socket. This syscall is very TCP-oriented, but it is also useful for udp socket.
+    /// Not like tcp, shutdown does nothing on the wire, it only changes shutdown states.
+    /// The shutdown states block the io-uring request of receiving or sending message.
+    pub async fn shutdown(&self, how: Shutdown) -> Result<()> {
+        let state = self.state.read().unwrap();
+        if !state.is_connected() {
+            return_errno!(ENOTCONN, "The udp socket is not connected");
+        }
+        drop(state);
+        self.common.host_shutdown(how)?;
+        match how {
+            Shutdown::Read => {
+                self.receiver.shutdown();
+                self.common.pollee().add_events(Events::IN);
+            }
+            Shutdown::Write => {
+                self.sender.shutdown();
+                self.common.pollee().add_events(Events::OUT);
+            }
+            Shutdown::Both => {
+                self.receiver.shutdown();
+                self.sender.shutdown();
+                self.common
+                    .pollee()
+                    .add_events(Events::IN | Events::OUT | Events::HUP);
+            }
+        }
+        Ok(())
+    }
+
     pub async fn read(&self, buf: &mut [u8]) -> Result<usize> {
         self.readv(&mut [buf]).await
     }
@@ -184,7 +216,11 @@ impl<A: Addr, R: Runtime> DatagramSocket<A, R> {
     /// That is because `recvfrom` doesn't privide a implicit binding. If you
     /// don't do a explicit or implicit binding, the sender doesn't know where
     /// to send the data.
-    pub async fn recvmsg(&self, bufs: &mut [&mut [u8]], flags: RecvFlags) -> Result<(usize, A)> {
+    pub async fn recvmsg(
+        &self,
+        bufs: &mut [&mut [u8]],
+        flags: RecvFlags,
+    ) -> Result<(usize, Option<A>)> {
         self.receiver.recvmsg(bufs, flags).await
     }
 

--- a/src/libos/crates/host-socket/src/datagram/mod.rs
+++ b/src/libos/crates/host-socket/src/datagram/mod.rs
@@ -328,6 +328,10 @@ impl<A: Addr, R: Runtime> DatagramSocket<A, R> {
             cmd: GetIfConf => {
                 cmd.execute(self.host_fd())?;
             },
+            cmd: GetReadBufLen => {
+                let read_buf_len = self.receiver.ready_len();
+                cmd.set_output(read_buf_len as _);
+            },
             _ => {
                 return_errno!(EINVAL, "Not supported yet");
             }

--- a/src/libos/crates/host-socket/src/datagram/mod.rs
+++ b/src/libos/crates/host-socket/src/datagram/mod.rs
@@ -226,7 +226,7 @@ impl<A: Addr, R: Runtime> DatagramSocket<A, R> {
         bufs: &mut [&mut [u8]],
         flags: RecvFlags,
         control: Option<&mut [u8]>,
-    ) -> Result<(usize, Option<A>, i32)> {
+    ) -> Result<(usize, Option<A>, i32, usize)> {
         self.receiver.recvmsg(bufs, flags, control).await
     }
 

--- a/src/libos/crates/host-socket/src/datagram/mod.rs
+++ b/src/libos/crates/host-socket/src/datagram/mod.rs
@@ -10,6 +10,10 @@ use crate::prelude::*;
 use crate::runtime::Runtime;
 use crate::sockopt::*;
 
+use async_io::socket::{
+    timeout_to_timeval, GetRecvTimeoutCmd, GetSendTimeoutCmd, SetRecvTimeoutCmd, SetSendTimeoutCmd,
+};
+
 const MAX_BUF_SIZE: usize = 64 * 1024;
 const OPTMEM_MAX: usize = 64 * 1024;
 
@@ -311,6 +315,20 @@ impl<A: Addr, R: Runtime> DatagramSocket<A, R> {
             cmd: SetSockOptRawCmd => {
                 cmd.execute(self.host_fd())?;
             },
+            cmd: SetRecvTimeoutCmd => {
+                self.set_recv_timeout(*cmd.timeout());
+            },
+            cmd: SetSendTimeoutCmd => {
+                self.set_send_timeout(*cmd.timeout());
+            },
+            cmd: GetRecvTimeoutCmd => {
+                let timeval = timeout_to_timeval(self.recv_timeout());
+                cmd.set_output(timeval);
+            },
+            cmd: GetSendTimeoutCmd => {
+                let timeval = timeout_to_timeval(self.send_timeout());
+                cmd.set_output(timeval);
+            },
             cmd: GetAcceptConnCmd => {
                 // Datagram doesn't support listen
                 cmd.set_output(0);
@@ -340,6 +358,22 @@ impl<A: Addr, R: Runtime> DatagramSocket<A, R> {
             }
         });
         Ok(())
+    }
+
+    fn send_timeout(&self) -> Option<Duration> {
+        self.common.send_timeout()
+    }
+
+    fn recv_timeout(&self) -> Option<Duration> {
+        self.common.recv_timeout()
+    }
+
+    fn set_send_timeout(&self, timeout: Duration) {
+        self.common.set_send_timeout(timeout);
+    }
+
+    fn set_recv_timeout(&self, timeout: Duration) {
+        self.common.set_recv_timeout(timeout);
     }
 
     fn cancel_requests(&self) {

--- a/src/libos/crates/host-socket/src/datagram/mod.rs
+++ b/src/libos/crates/host-socket/src/datagram/mod.rs
@@ -222,7 +222,7 @@ impl<A: Addr, R: Runtime> DatagramSocket<A, R> {
         bufs: &mut [&mut [u8]],
         flags: RecvFlags,
         control: Option<&mut [u8]>,
-    ) -> Result<(usize, Option<A>)> {
+    ) -> Result<(usize, Option<A>, i32)> {
         self.receiver.recvmsg(bufs, flags, control).await
     }
 

--- a/src/libos/crates/host-socket/src/datagram/receiver.rs
+++ b/src/libos/crates/host-socket/src/datagram/receiver.rs
@@ -22,7 +22,7 @@ impl<A: Addr, R: Runtime> Receiver<A, R> {
         self: &Arc<Self>,
         bufs: &mut [&mut [u8]],
         flags: RecvFlags,
-    ) -> Result<(usize, A)> {
+    ) -> Result<(usize, Option<A>)> {
         let mask = Events::IN;
         // Initialize the poller only when needed
         let mut poller = None;
@@ -33,8 +33,13 @@ impl<A: Addr, R: Runtime> Receiver<A, R> {
                 return res;
             }
 
+            // Need more handles for flags not MSG_DONTWAIT
             if self.common.nonblocking() || flags.contains(RecvFlags::MSG_DONTWAIT) {
                 return_errno!(EAGAIN, "no data are present to be received");
+            }
+
+            if self.is_shutdown() {
+                return Ok((0, None));
             }
 
             // Wait for interesting events by polling
@@ -54,11 +59,12 @@ impl<A: Addr, R: Runtime> Receiver<A, R> {
         self: &Arc<Self>,
         bufs: &mut [&mut [u8]],
         flags: RecvFlags,
-    ) -> Result<(usize, A)> {
+    ) -> Result<(usize, Option<A>)> {
         let mut inner = self.inner.lock().unwrap();
 
         if !flags.is_empty() && flags != RecvFlags::MSG_DONTWAIT {
-            todo!("Support other flags");
+            // todo!("Support other flags");
+            return_errno!(EINVAL, "the socket flags is not supported");
         }
 
         // Mark the socket as non-readable since Datagram uses single packet
@@ -67,7 +73,7 @@ impl<A: Addr, R: Runtime> Receiver<A, R> {
         // Copy data from the recv buffer to the bufs
         let recv_bytes = inner.try_copy_buf(bufs);
         if let Some(recv_bytes) = recv_bytes {
-            let recv_addr = inner.get_addr().unwrap();
+            let recv_addr = inner.get_packet_addr();
             self.do_recv(&mut inner);
             return Ok((recv_bytes, recv_addr));
         }
@@ -75,6 +81,10 @@ impl<A: Addr, R: Runtime> Receiver<A, R> {
         if let Some(errno) = inner.error {
             self.do_recv(&mut inner);
             return_errno!(errno, "recv failed");
+        }
+
+        if inner.is_shutdown {
+            return_errno!(Errno::EWOULDBLOCK, "the socket recv has been shutdown");
         }
 
         self.do_recv(&mut inner);
@@ -88,6 +98,11 @@ impl<A: Addr, R: Runtime> Receiver<A, R> {
         // Clear recv_len and error
         inner.recv_len.take();
         inner.error.take();
+
+        if inner.is_shutdown {
+            info!("do_recv early return, the socket recv has been shutdown");
+            return;
+        }
 
         let receiver = self.clone();
         // Init the callback invoked upon the completion of the async recv
@@ -110,19 +125,6 @@ impl<A: Addr, R: Runtime> Receiver<A, R> {
                 // TODO: add PRI event if set SO_SELECT_ERR_QUEUE
                 receiver.common.pollee().add_events(Events::ERR);
                 return;
-            }
-
-            // If the socket is connected, we will filter the recv message
-            // according to the peer address. Only the message from the connected
-            // peer is reserved.
-            if let Some(peer) = receiver.common.peer_addr() {
-                // There must be a address
-                let recv_addr: A = inner.get_addr().unwrap();
-                // Ignore the message if it's not from the peer
-                if recv_addr != peer {
-                    receiver.do_recv(&mut inner);
-                    return;
-                }
             }
 
             // Handle the normal case of a successful read
@@ -154,6 +156,23 @@ impl<A: Addr, R: Runtime> Receiver<A, R> {
             unsafe { io_uring.cancel(io_handle) };
         }
     }
+
+    /// Shutdown udp receiver.
+    pub fn shutdown(&self) {
+        let mut inner = self.inner.lock().unwrap();
+        inner.is_shutdown = true;
+    }
+
+    /// Reset udp receiver shutdown state.
+    pub fn reset_shutdown(&self) {
+        let mut inner = self.inner.lock().unwrap();
+        inner.is_shutdown = false;
+    }
+
+    /// Obtain udp receiver shutdown state.
+    fn is_shutdown(&self) -> bool {
+        self.inner.lock().unwrap().is_shutdown
+    }
 }
 
 struct Inner {
@@ -164,6 +183,7 @@ struct Inner {
     req: UntrustedBox<RecvReq>,
     io_handle: Option<IoHandle>,
     error: Option<Errno>,
+    is_shutdown: bool,
 }
 
 unsafe impl Send for Inner {}
@@ -176,6 +196,7 @@ impl Inner {
             req: UntrustedBox::new_uninit(),
             io_handle: None,
             error: None,
+            is_shutdown: false,
         }
     }
 
@@ -217,7 +238,9 @@ impl Inner {
         })
     }
 
-    pub fn get_addr<A: Addr>(&self) -> Option<A> {
+    /// Return the addr of the received packet if udp socket is not connected.
+    /// Return None if udp socket is connected.
+    pub fn get_packet_addr<A: Addr>(&self) -> Option<A> {
         let recv_addr_len = self.req.msg.msg_namelen as usize;
         A::from_c_storage(&self.req.addr, recv_addr_len).ok()
     }

--- a/src/libos/crates/host-socket/src/datagram/receiver.rs
+++ b/src/libos/crates/host-socket/src/datagram/receiver.rs
@@ -173,6 +173,11 @@ impl<A: Addr, R: Runtime> Receiver<A, R> {
     fn is_shutdown(&self) -> bool {
         self.inner.lock().unwrap().is_shutdown
     }
+
+    pub fn ready_len(&self) -> usize {
+        let inner = self.inner.lock().unwrap();
+        inner.recv_len().unwrap_or(0)
+    }
 }
 
 struct Inner {
@@ -236,6 +241,10 @@ impl Inner {
             }
             copy_len
         })
+    }
+
+    pub fn recv_len(&self) -> Option<usize> {
+        self.recv_len
     }
 
     /// Return the addr of the received packet if udp socket is not connected.

--- a/src/libos/crates/host-socket/src/datagram/receiver.rs
+++ b/src/libos/crates/host-socket/src/datagram/receiver.rs
@@ -24,7 +24,7 @@ impl<A: Addr, R: Runtime> Receiver<A, R> {
         bufs: &mut [&mut [u8]],
         flags: RecvFlags,
         mut control: Option<&mut [u8]>,
-    ) -> Result<(usize, Option<A>)> {
+    ) -> Result<(usize, Option<A>, i32)> {
         let mask = Events::IN;
         // Initialize the poller only when needed
         let mut poller = None;
@@ -44,7 +44,7 @@ impl<A: Addr, R: Runtime> Receiver<A, R> {
             }
 
             if self.is_shutdown() {
-                return Ok((0, None));
+                return Ok((0, None, flags.bits()));
             }
 
             // Wait for interesting events by polling
@@ -65,10 +65,13 @@ impl<A: Addr, R: Runtime> Receiver<A, R> {
         bufs: &mut [&mut [u8]],
         flags: RecvFlags,
         control: &mut Option<&mut [u8]>,
-    ) -> Result<(usize, Option<A>)> {
+    ) -> Result<(usize, Option<A>, i32)> {
         let mut inner = self.inner.lock().unwrap();
 
-        if !flags.is_empty() && flags != RecvFlags::MSG_DONTWAIT && flags != RecvFlags::MSG_ERRQUEUE
+        if !flags.is_empty()
+            && flags.intersects(
+                !(RecvFlags::MSG_DONTWAIT | RecvFlags::MSG_ERRQUEUE | RecvFlags::MSG_TRUNC),
+            )
         {
             // todo!("Support other flags");
             return_errno!(EINVAL, "the socket flags is not supported");
@@ -78,16 +81,32 @@ impl<A: Addr, R: Runtime> Receiver<A, R> {
         self.common.pollee().del_events(Events::IN);
 
         // Copy data from the recv buffer to the bufs
-        let recv_bytes = inner.try_copy_buf(bufs);
-        if let Some(recv_bytes) = recv_bytes {
+        let copied_bytes = inner.try_copy_buf(bufs);
+        if let Some(copied_bytes) = copied_bytes {
             let recv_addr = inner.get_packet_addr();
             // Copy ancillary data from control buffer
-            control
-                .as_mut()
-                .map(|buf| buf.copy_from_slice(&inner.msg_control[..buf.len()]));
+            if inner.req.msg.msg_controllen > 0 {
+                control
+                    .as_mut()
+                    .map(|buf| buf.copy_from_slice(&inner.msg_control[..buf.len()]));
+            }
+
+            let bufs_len: usize = bufs.iter().map(|buf| buf.len()).sum();
+            let msg_flags = if bufs_len < inner.recv_len().unwrap() {
+                RecvFlags::MSG_TRUNC
+            } else {
+                flags
+            }
+            .bits();
+
+            let recv_bytes = if flags.contains(RecvFlags::MSG_TRUNC) {
+                inner.recv_len().unwrap()
+            } else {
+                copied_bytes
+            };
 
             self.do_recv(&mut inner);
-            return Ok((recv_bytes, recv_addr));
+            return Ok((recv_bytes, recv_addr, msg_flags));
         }
 
         if let Some(errno) = inner.error {

--- a/src/libos/crates/host-socket/src/datagram/receiver.rs
+++ b/src/libos/crates/host-socket/src/datagram/receiver.rs
@@ -55,7 +55,22 @@ impl<A: Addr, R: Runtime> Receiver<A, R> {
             }
             let events = self.common.pollee().poll(mask, None);
             if events.is_empty() {
-                poller.as_ref().unwrap().wait().await?;
+                let ret = poller
+                    .as_ref()
+                    .unwrap()
+                    .wait_timeout(self.common.recv_timeout().as_mut())
+                    .await;
+                if let Err(e) = ret {
+                    warn!("recv wait errno = {:?}", e.errno());
+                    match e.errno() {
+                        ETIMEDOUT => {
+                            return_errno!(EAGAIN, "timeout reached")
+                        }
+                        _ => {
+                            return_errno!(e.errno(), "wait error")
+                        }
+                    }
+                }
             }
         }
     }

--- a/src/libos/crates/host-socket/src/datagram/receiver.rs
+++ b/src/libos/crates/host-socket/src/datagram/receiver.rs
@@ -6,6 +6,7 @@ use sgx_untrusted_alloc::{MaybeUntrusted, UntrustedBox};
 use crate::common::Common;
 use crate::prelude::*;
 use crate::runtime::Runtime;
+use core::ffi::c_void;
 
 pub struct Receiver<A: Addr + 'static, R: Runtime> {
     common: Arc<Common<A, R>>,
@@ -22,19 +23,23 @@ impl<A: Addr, R: Runtime> Receiver<A, R> {
         self: &Arc<Self>,
         bufs: &mut [&mut [u8]],
         flags: RecvFlags,
+        mut control: Option<&mut [u8]>,
     ) -> Result<(usize, Option<A>)> {
         let mask = Events::IN;
         // Initialize the poller only when needed
         let mut poller = None;
         loop {
             // Attempt to recv
-            let res = self.try_recvmsg(bufs, flags);
+            let res = self.try_recvmsg(bufs, flags, &mut control);
             if !res.has_errno(EAGAIN) {
                 return res;
             }
 
             // Need more handles for flags not MSG_DONTWAIT
-            if self.common.nonblocking() || flags.contains(RecvFlags::MSG_DONTWAIT) {
+            if self.common.nonblocking()
+                || flags.contains(RecvFlags::MSG_DONTWAIT)
+                || flags.contains(RecvFlags::MSG_ERRQUEUE)
+            {
                 return_errno!(EAGAIN, "no data are present to be received");
             }
 
@@ -59,10 +64,12 @@ impl<A: Addr, R: Runtime> Receiver<A, R> {
         self: &Arc<Self>,
         bufs: &mut [&mut [u8]],
         flags: RecvFlags,
+        control: &mut Option<&mut [u8]>,
     ) -> Result<(usize, Option<A>)> {
         let mut inner = self.inner.lock().unwrap();
 
-        if !flags.is_empty() && flags != RecvFlags::MSG_DONTWAIT {
+        if !flags.is_empty() && flags != RecvFlags::MSG_DONTWAIT && flags != RecvFlags::MSG_ERRQUEUE
+        {
             // todo!("Support other flags");
             return_errno!(EINVAL, "the socket flags is not supported");
         }
@@ -74,6 +81,11 @@ impl<A: Addr, R: Runtime> Receiver<A, R> {
         let recv_bytes = inner.try_copy_buf(bufs);
         if let Some(recv_bytes) = recv_bytes {
             let recv_addr = inner.get_packet_addr();
+            // Copy ancillary data from control buffer
+            control
+                .as_mut()
+                .map(|buf| buf.copy_from_slice(&inner.msg_control[..buf.len()]));
+
             self.do_recv(&mut inner);
             return Ok((recv_bytes, recv_addr));
         }
@@ -185,6 +197,7 @@ struct Inner {
     // Datagram sockets in various domains permit zero-length datagrams.
     // Hence the recv_len might be 0.
     recv_len: Option<usize>,
+    msg_control: UntrustedBox<[u8]>,
     req: UntrustedBox<RecvReq>,
     io_handle: Option<IoHandle>,
     error: Option<Errno>,
@@ -198,6 +211,7 @@ impl Inner {
         Self {
             recv_buf: UntrustedBox::new_uninit_slice(super::MAX_BUF_SIZE),
             recv_len: None,
+            msg_control: UntrustedBox::new_uninit_slice(super::OPTMEM_MAX),
             req: UntrustedBox::new_uninit(),
             io_handle: None,
             error: None,
@@ -218,6 +232,10 @@ impl Inner {
         msg.msg_iovlen = 1;
         msg.msg_name = &raw mut self.req.addr as _;
         msg.msg_namelen = std::mem::size_of::<libc::sockaddr_storage>() as _;
+
+        self.req.control = self.msg_control.as_mut_ptr() as _;
+        msg.msg_control = self.req.control as _;
+        msg.msg_controllen = self.msg_control.len() as _;
 
         self.req.msg = msg;
         self.req.iovec = iovec;
@@ -260,6 +278,7 @@ struct RecvReq {
     msg: libc::msghdr,
     iovec: libc::iovec,
     addr: libc::sockaddr_storage,
+    control: *mut c_void,
 }
 
 unsafe impl MaybeUntrusted for RecvReq {}

--- a/src/libos/crates/host-socket/src/datagram/receiver.rs
+++ b/src/libos/crates/host-socket/src/datagram/receiver.rs
@@ -70,7 +70,10 @@ impl<A: Addr, R: Runtime> Receiver<A, R> {
 
         if !flags.is_empty()
             && flags.intersects(
-                !(RecvFlags::MSG_DONTWAIT | RecvFlags::MSG_ERRQUEUE | RecvFlags::MSG_TRUNC),
+                !(RecvFlags::MSG_DONTWAIT
+                    | RecvFlags::MSG_ERRQUEUE
+                    | RecvFlags::MSG_TRUNC
+                    | RecvFlags::MSG_PEEK),
             )
         {
             // todo!("Support other flags");
@@ -105,7 +108,13 @@ impl<A: Addr, R: Runtime> Receiver<A, R> {
                 copied_bytes
             };
 
-            self.do_recv(&mut inner);
+            // When flags contain MSG_PEEK and there is data in socket recv buffer, it is unnecessary to
+            // send blocking recv request (do_recv) to fetch data from iouring buffer, which may flush the data in recv buffer.
+            // When flags don't contain MSG_PEEK or there is no available data, it is time to send blocking request to iouring for notifying events.
+            if !flags.contains(RecvFlags::MSG_PEEK) {
+                self.do_recv(&mut inner);
+            }
+
             return Ok((recv_bytes, recv_addr, msg_flags));
         }
 

--- a/src/libos/crates/host-socket/src/datagram/sender.rs
+++ b/src/libos/crates/host-socket/src/datagram/sender.rs
@@ -1,6 +1,8 @@
+use core::sync::atomic::{AtomicBool, Ordering};
 use std::ptr::{self};
 
 use io_uring_callback::Fd;
+use sgx_trts::libc::EWOULDBLOCK;
 use sgx_untrusted_alloc::{MaybeUntrusted, UntrustedBox};
 
 use crate::common::Common;
@@ -9,15 +11,38 @@ use crate::runtime::Runtime;
 
 pub struct Sender<A: Addr + 'static, R: Runtime> {
     common: Arc<Common<A, R>>,
+    is_shutdown: AtomicBool,
 }
 
 impl<A: Addr, R: Runtime> Sender<A, R> {
     pub fn new(common: Arc<Common<A, R>>) -> Self {
         common.pollee().add_events(Events::OUT);
-        Self { common }
+        let is_shutdown = AtomicBool::new(false);
+        Self {
+            common,
+            is_shutdown,
+        }
+    }
+
+    /// Shutdown udp sender.
+    pub fn shutdown(&self) {
+        self.is_shutdown.store(true, Ordering::Relaxed)
+    }
+
+    /// Reset udp sender shutdown state.
+    pub fn reset_shutdown(&self) {
+        self.is_shutdown.store(false, Ordering::Relaxed)
+    }
+
+    /// Obtain udp sender shutdown state.
+    fn is_shutdown(&self) -> bool {
+        self.is_shutdown.load(Ordering::Relaxed)
     }
 
     pub async fn sendmsg(&self, bufs: &[&[u8]], addr: &A, flags: SendFlags) -> Result<usize> {
+        if self.is_shutdown() {
+            return_errno!(Errno::EWOULDBLOCK, "the write has been shutdown")
+        }
         let total_len: usize = bufs.iter().map(|buf| buf.len()).sum();
         if total_len > super::MAX_BUF_SIZE {
             return_errno!(EMSGSIZE, "the message is too large")

--- a/src/libos/crates/host-socket/src/prelude.rs
+++ b/src/libos/crates/host-socket/src/prelude.rs
@@ -1,6 +1,7 @@
 // Convenient reexports for internal uses.
 pub(crate) use errno::prelude::*;
 pub(crate) use std::sync::Arc;
+pub(crate) use std::time::Duration;
 
 cfg_if::cfg_if! {
     if #[cfg(feature = "sgx")] {

--- a/src/libos/crates/host-socket/src/stream/mod.rs
+++ b/src/libos/crates/host-socket/src/stream/mod.rs
@@ -206,7 +206,7 @@ impl<A: Addr, R: Runtime> StreamSocket<A, R> {
             match &*state {
                 State::Connected(connected_stream) => connected_stream.clone(),
                 _ => {
-                    return_errno!(EINVAL, "the socket is not connected");
+                    return_errno!(ENOTCONN, "the socket is not connected");
                 }
             }
         };
@@ -228,7 +228,7 @@ impl<A: Addr, R: Runtime> StreamSocket<A, R> {
             match &*state {
                 State::Connected(connected_stream) => connected_stream.clone(),
                 _ => {
-                    return_errno!(ENOTCONN, "the socket is not connected");
+                    return_errno!(EPIPE, "the socket is not connected");
                 }
             }
         };

--- a/src/libos/crates/host-socket/src/stream/mod.rs
+++ b/src/libos/crates/host-socket/src/stream/mod.rs
@@ -38,7 +38,7 @@ impl<A: Addr, R: Runtime> StreamSocket<A, R> {
     fn set_init_state(&self) -> Result<()> {
         let mut state = self.state.write().unwrap();
         match &*state {
-            State::Init(init_stream) => {
+            State::Init(_) => {
                 warn!("already in init state");
             }
             State::Listen(listener_stream) => {
@@ -65,6 +65,21 @@ impl<A: Addr, R: Runtime> StreamSocket<A, R> {
     fn new_connected(connected_stream: Arc<ConnectedStream<A, R>>) -> Self {
         let state = RwLock::new(State::Connected(connected_stream));
         Self { state }
+    }
+
+    fn try_switch_to_connected_state(
+        connecting_stream: &Arc<ConnectingStream<A, R>>,
+    ) -> Option<Arc<ConnectedStream<A, R>>> {
+        // Connecting state only exists for non-blocking socket
+        assert!(connecting_stream.common().nonblocking());
+
+        if connecting_stream.check_connection() {
+            let common = connecting_stream.common().clone();
+            common.set_peer_addr(connecting_stream.peer_addr());
+            Some(ConnectedStream::new(common))
+        } else {
+            None
+        }
     }
 
     pub fn domain(&self) -> Domain {
@@ -134,8 +149,18 @@ impl<A: Addr, R: Runtime> StreamSocket<A, R> {
                     *state = State::Connect(connecting_stream.clone());
                     (init_stream, connecting_stream)
                 }
-                State::Connect(_) => {
-                    return_errno!(EALREADY, "the socket is already connecting");
+                State::Connect(connecting_stream) => {
+                    if let Some(connected_stream) =
+                        Self::try_switch_to_connected_state(connecting_stream)
+                    {
+                        *state = State::Connected(connected_stream);
+                        return_errno!(EISCONN, "the socket is already connected");
+                    } else {
+                        // Not connected, keep the connecting state and try connect
+                        let init_stream =
+                            InitStream::new_with_common(connecting_stream.common().clone())?;
+                        (init_stream, connecting_stream.clone())
+                    }
                 }
                 State::Connected(_) => {
                     return_errno!(EISCONN, "the socket is already connected");
@@ -148,8 +173,9 @@ impl<A: Addr, R: Runtime> StreamSocket<A, R> {
 
         let res = connecting_stream.connect().await;
 
-        // If success, then the state transits to connected; otherwise,
-        // the state is restored to the init state.
+        // If success, then the state is switched to connected; otherwise, for blocking socket
+        // the state is restored to the init state, and for non-blocking socket, the state
+        // keeps in connecting state.
         match &res {
             Ok(()) => {
                 let connected_stream = {
@@ -162,8 +188,10 @@ impl<A: Addr, R: Runtime> StreamSocket<A, R> {
                 *state = State::Connected(connected_stream);
             }
             Err(_) => {
-                let mut state = self.state.write().unwrap();
-                *state = State::Init(init_stream);
+                if !connecting_stream.common().nonblocking() {
+                    let mut state = self.state.write().unwrap();
+                    *state = State::Init(init_stream);
+                }
             }
         }
         res
@@ -206,9 +234,19 @@ impl<A: Addr, R: Runtime> StreamSocket<A, R> {
         flags: RecvFlags,
     ) -> Result<(usize, Option<A>)> {
         let connected_stream = {
-            let state = self.state.read().unwrap();
+            let mut state = self.state.write().unwrap();
             match &*state {
                 State::Connected(connected_stream) => connected_stream.clone(),
+                State::Connect(connecting_stream) => {
+                    if let Some(connected_stream) =
+                        Self::try_switch_to_connected_state(connecting_stream)
+                    {
+                        *state = State::Connected(connected_stream.clone());
+                        connected_stream
+                    } else {
+                        return_errno!(ENOTCONN, "the socket is not connected");
+                    }
+                }
                 _ => {
                     return_errno!(ENOTCONN, "the socket is not connected");
                 }
@@ -229,9 +267,19 @@ impl<A: Addr, R: Runtime> StreamSocket<A, R> {
 
     pub async fn sendmsg(&self, bufs: &[&[u8]], flags: SendFlags) -> Result<usize> {
         let connected_stream = {
-            let state = self.state.read().unwrap();
+            let mut state = self.state.write().unwrap();
             match &*state {
                 State::Connected(connected_stream) => connected_stream.clone(),
+                State::Connect(connecting_stream) => {
+                    if let Some(connected_stream) =
+                        Self::try_switch_to_connected_state(connecting_stream)
+                    {
+                        *state = State::Connected(connected_stream.clone());
+                        connected_stream
+                    } else {
+                        return_errno!(ENOTCONN, "the socket is not connected");
+                    }
+                }
                 _ => {
                     return_errno!(EPIPE, "the socket is not connected");
                 }
@@ -352,7 +400,7 @@ impl<A: Addr, R: Runtime> StreamSocket<A, R> {
     }
 
     pub async fn shutdown(&self, shutdown: Shutdown) -> Result<()> {
-        let state = self.state.read().unwrap();
+        let mut state = self.state.write().unwrap();
         match &*state {
             State::Listen(listener_stream) => {
                 // listening socket can be shutdown and then re-use by calling listen again.
@@ -368,6 +416,17 @@ impl<A: Addr, R: Runtime> StreamSocket<A, R> {
                 }
             }
             State::Connected(connected_stream) => connected_stream.shutdown(shutdown),
+            State::Connect(connecting_stream) => {
+                if let Some(connected_stream) =
+                    Self::try_switch_to_connected_state(connecting_stream)
+                {
+                    connected_stream.shutdown(shutdown)?;
+                    *state = State::Connected(connected_stream);
+                    Ok(())
+                } else {
+                    return_errno!(ENOTCONN, "the socket is not connected");
+                }
+            }
             _ => {
                 return_errno!(ENOTCONN, "the socket is not connected");
             }

--- a/src/libos/crates/host-socket/src/stream/mod.rs
+++ b/src/libos/crates/host-socket/src/stream/mod.rs
@@ -35,6 +35,24 @@ impl<A: Addr, R: Runtime> StreamSocket<A, R> {
         })
     }
 
+    fn set_init_state(&self) -> Result<()> {
+        let mut state = self.state.write().unwrap();
+        match &*state {
+            State::Init(init_stream) => {
+                warn!("already in init state");
+            }
+            State::Listen(listener_stream) => {
+                let init_stream = InitStream::new_with_common(listener_stream.common().clone())?;
+                let init_state = State::Init(init_stream);
+                *state = init_state;
+            }
+            _ => {
+                return_errno!(EINVAL, "invalid state transition");
+            }
+        }
+        Ok(())
+    }
+
     pub fn new_pair(nonblocking: bool) -> Result<(Self, Self)> {
         let (common1, common2) = Common::new_pair(Type::STREAM, nonblocking)?;
         let connected1 = ConnectedStream::new(Arc::new(common1));
@@ -331,8 +349,18 @@ impl<A: Addr, R: Runtime> StreamSocket<A, R> {
     pub fn shutdown(&self, shutdown: Shutdown) -> Result<()> {
         let state = self.state.read().unwrap();
         match &*state {
+            State::Listen(listener_stream) => {
+                // listening socket can be shutdown and then re-use by calling listen again.
+                listener_stream.shutdown(shutdown)?;
+                if shutdown.should_shut_read() {
+                    drop(state);
+                    self.set_init_state()
+                } else {
+                    // shutdown the writer of the listener expect to have no effect
+                    Ok(())
+                }
+            }
             State::Connected(connected_stream) => connected_stream.shutdown(shutdown),
-            State::Listen(listener_stream) => listener_stream.shutdown(shutdown),
             _ => {
                 return_errno!(ENOTCONN, "the socket is not connected");
             }

--- a/src/libos/crates/host-socket/src/stream/mod.rs
+++ b/src/libos/crates/host-socket/src/stream/mod.rs
@@ -329,17 +329,14 @@ impl<A: Addr, R: Runtime> StreamSocket<A, R> {
     }
 
     pub fn shutdown(&self, shutdown: Shutdown) -> Result<()> {
-        let connected_stream = {
-            let state = self.state.read().unwrap();
-            match &*state {
-                State::Connected(connected_stream) => connected_stream.clone(),
-                _ => {
-                    return_errno!(ENOTCONN, "the socket is not connected");
-                }
+        let state = self.state.read().unwrap();
+        match &*state {
+            State::Connected(connected_stream) => connected_stream.shutdown(shutdown),
+            State::Listen(listener_stream) => listener_stream.shutdown(shutdown),
+            _ => {
+                return_errno!(ENOTCONN, "the socket is not connected");
             }
-        };
-
-        connected_stream.shutdown(shutdown)
+        }
     }
 
     fn cancel_requests(&self) {

--- a/src/libos/crates/host-socket/src/stream/mod.rs
+++ b/src/libos/crates/host-socket/src/stream/mod.rs
@@ -219,7 +219,7 @@ impl<A: Addr, R: Runtime> StreamSocket<A, R> {
     }
 
     pub async fn readv(&self, bufs: &mut [&mut [u8]]) -> Result<usize> {
-        let ret = self.recvmsg(bufs, RecvFlags::empty()).await?;
+        let ret = self.recvmsg(bufs, RecvFlags::empty(), None).await?;
         Ok(ret.0)
     }
 
@@ -232,6 +232,7 @@ impl<A: Addr, R: Runtime> StreamSocket<A, R> {
         &self,
         buf: &mut [&mut [u8]],
         flags: RecvFlags,
+        control: Option<&mut [u8]>,
     ) -> Result<(usize, Option<A>)> {
         let connected_stream = {
             let mut state = self.state.write().unwrap();

--- a/src/libos/crates/host-socket/src/stream/states/connect.rs
+++ b/src/libos/crates/host-socket/src/stream/states/connect.rs
@@ -49,7 +49,23 @@ impl<A: Addr + 'static, R: Runtime> ConnectingStream<A, R> {
             if !events.is_empty() {
                 break;
             }
-            poller.wait().await?;
+            let ret = poller
+                .wait_timeout(self.common.send_timeout().as_mut())
+                .await;
+            if let Err(e) = ret {
+                warn!("connect wait errno = {:?}", e.errno());
+                match e.errno() {
+                    ETIMEDOUT => {
+                        // Cancel connect request if timeout
+                        self.cancel_connect_request();
+                        // This error code is same as the connect timeout error code on Linux
+                        return_errno!(EINPROGRESS, "timeout reached")
+                    }
+                    _ => {
+                        return_errno!(e.errno(), "wait error")
+                    }
+                }
+            }
         }
 
         // Finish the async connect
@@ -72,6 +88,10 @@ impl<A: Addr + 'static, R: Runtime> ConnectingStream<A, R> {
                 // Store the errno
                 let mut req = arc_self.req.lock().unwrap();
                 let errno = Errno::from(-retval as u32);
+                // If connect request is canceled, just ignore it to avoid spurious wake up on the other end
+                if errno == ECANCELED {
+                    return;
+                }
                 req.errno = Some(errno);
                 drop(req);
 
@@ -93,6 +113,14 @@ impl<A: Addr + 'static, R: Runtime> ConnectingStream<A, R> {
             )
         };
         req.io_handle = Some(io_handle);
+    }
+
+    fn cancel_connect_request(&self) {
+        let io_uring = self.common.io_uring();
+        let req = self.req.lock().unwrap();
+        if let Some(io_handle) = &req.io_handle {
+            unsafe { io_uring.cancel(io_handle) };
+        }
     }
 
     #[allow(dead_code)]

--- a/src/libos/crates/host-socket/src/stream/states/connected/recv.rs
+++ b/src/libos/crates/host-socket/src/stream/states/connected/recv.rs
@@ -71,6 +71,10 @@ impl<A: Addr + 'static, R: Runtime> ConnectedStream<A, R> {
                     warn!("recv wait errno = {:?}", e.errno());
                     match e.errno() {
                         ETIMEDOUT => {
+                            // For recv with MSG_WAITALL, return total received bytes if timeout
+                            if flags.contains(RecvFlags::MSG_WAITALL) && total_received > 0 {
+                                return Ok(total_received);
+                            }
                             return_errno!(EAGAIN, "timeout reached")
                         }
                         _ => {

--- a/src/libos/crates/host-socket/src/stream/states/connected/recv.rs
+++ b/src/libos/crates/host-socket/src/stream/states/connected/recv.rs
@@ -98,7 +98,8 @@ impl<A: Addr + 'static, R: Runtime> ConnectedStream<A, R> {
         if !flags.is_empty()
             && flags.intersects(!(RecvFlags::MSG_DONTWAIT | RecvFlags::MSG_WAITALL))
         {
-            todo!("Support other flags: {:?}", flags);
+            warn!("Unsupported flags: {:?}", flags);
+            return_errno!(EINVAL, "flags not supported");
         }
 
         let res = {

--- a/src/libos/crates/host-socket/src/stream/states/connected/recv.rs
+++ b/src/libos/crates/host-socket/src/stream/states/connected/recv.rs
@@ -216,15 +216,47 @@ impl<A: Addr + 'static, R: Runtime> ConnectedStream<A, R> {
     }
 
     pub(super) fn initiate_async_recv(self: &Arc<Self>) {
+        // trace!("initiate async recv");
         let mut inner = self.receiver.inner.lock().unwrap();
         self.do_recv(&mut inner);
     }
 
-    pub fn cancel_requests(&self) {
-        let inner = self.receiver.inner.lock().unwrap();
-        if let Some(io_handle) = &inner.io_handle {
-            let io_uring = self.common.io_uring();
-            unsafe { io_uring.cancel(io_handle) };
+    pub async fn cancel_recv_requests(&self) {
+        {
+            let inner = self.receiver.inner.lock().unwrap();
+            if let Some(io_handle) = &inner.io_handle {
+                let io_uring = self.common.io_uring();
+                unsafe { io_uring.cancel(io_handle) };
+            } else {
+                return;
+            }
+        }
+
+        // Mark the socket end as shutdown
+        self.receiver.shutdown();
+        self.sender.shutdown();
+
+        // wait for the cancel to complete
+        let poller = Poller::new();
+        let mask = Events::ERR | Events::IN;
+        self.common.pollee().connect_poller(mask, &poller);
+
+        loop {
+            let pending_request_exist = {
+                let inner = self.receiver.inner.lock().unwrap();
+                inner.io_handle.is_some()
+            };
+
+            if pending_request_exist {
+                let mut timeout = Some(Duration::from_secs(10));
+                let ret = poller.wait_timeout(timeout.as_mut()).await;
+                if let Err(e) = ret {
+                    warn!("cancel wait error = {:?}", e.errno());
+                    continue;
+                }
+            } else {
+                break;
+            }
         }
     }
 

--- a/src/libos/crates/host-socket/src/stream/states/connected/recv.rs
+++ b/src/libos/crates/host-socket/src/stream/states/connected/recv.rs
@@ -62,7 +62,22 @@ impl<A: Addr + 'static, R: Runtime> ConnectedStream<A, R> {
             }
             let events = self.common.pollee().poll(mask, None);
             if events.is_empty() {
-                poller.as_ref().unwrap().wait().await?;
+                let ret = poller
+                    .as_ref()
+                    .unwrap()
+                    .wait_timeout(self.common.recv_timeout().as_mut())
+                    .await;
+                if let Err(e) = ret {
+                    warn!("recv wait errno = {:?}", e.errno());
+                    match e.errno() {
+                        ETIMEDOUT => {
+                            return_errno!(EAGAIN, "timeout reached")
+                        }
+                        _ => {
+                            return_errno!(e.errno(), "wait error")
+                        }
+                    }
+                }
             }
         }
     }

--- a/src/libos/crates/host-socket/src/stream/states/connected/send.rs
+++ b/src/libos/crates/host-socket/src/stream/states/connected/send.rs
@@ -102,6 +102,8 @@ impl<A: Addr + 'static, R: Runtime> ConnectedStream<A, R> {
         }
         // Case 2. If the connenction has been broken...
         if let Some(errno) = inner.fatal {
+            // Reset error
+            inner.fatal = None;
             return_errno!(errno, "write failed");
         }
 

--- a/src/libos/crates/host-socket/src/stream/states/connected/send.rs
+++ b/src/libos/crates/host-socket/src/stream/states/connected/send.rs
@@ -56,7 +56,24 @@ impl<A: Addr + 'static, R: Runtime> ConnectedStream<A, R> {
 
             let events = self.common.pollee().poll(mask, None);
             if events.is_empty() {
-                poller.as_ref().unwrap().wait().await?;
+                let ret = poller
+                    .as_ref()
+                    .unwrap()
+                    .wait_timeout(self.common.send_timeout().as_mut())
+                    .await;
+                if let Err(e) = ret {
+                    warn!("send wait errno = {:?}", e.errno());
+                    match e.errno() {
+                        ETIMEDOUT => {
+                            // Just cancel send requests if timeout
+                            self.cancel_send_requests();
+                            return_errno!(EAGAIN, "timeout reached")
+                        }
+                        _ => {
+                            return_errno!(e.errno(), "wait error")
+                        }
+                    }
+                }
             }
         }
     }
@@ -151,6 +168,11 @@ impl<A: Addr + 'static, R: Runtime> ConnectedStream<A, R> {
                 // TODO: guard against Iago attack through errno
                 // TODO: should we ignore EINTR and try again?
                 let errno = Errno::from(-retval as u32);
+                // If send request is canceled, just ignore it to avoid spurious wake up on the other end.
+                if errno == ECANCELED {
+                    return;
+                }
+
                 inner.fatal = Some(errno);
                 stream.common.pollee().add_events(Events::ERR);
                 return;
@@ -184,6 +206,16 @@ impl<A: Addr + 'static, R: Runtime> ConnectedStream<A, R> {
         let host_fd = Fd(self.common.host_fd() as _);
         let handle = unsafe { io_uring.sendmsg(host_fd, msghdr_ptr, 0, complete_fn) };
         inner.io_handle.replace(handle);
+    }
+
+    fn cancel_send_requests(&self) {
+        let io_uring = self.common.io_uring();
+        let inner = self.sender.inner.lock().unwrap();
+        if let Some(io_handle) = &inner.io_handle {
+            unsafe { io_uring.cancel(io_handle) };
+        } else {
+            return;
+        }
     }
 }
 

--- a/src/libos/crates/host-socket/src/stream/states/init.rs
+++ b/src/libos/crates/host-socket/src/stream/states/init.rs
@@ -21,6 +21,12 @@ impl<A: Addr + 'static, R: Runtime> InitStream<A, R> {
         Ok(Arc::new(new_self))
     }
 
+    pub fn new_with_common(common: Arc<Common<A, R>>) -> Result<Arc<Self>> {
+        let inner = Mutex::new(Inner::new());
+        let new_self = Self { common, inner };
+        Ok(Arc::new(new_self))
+    }
+
     pub fn bind(&self, addr: &A) -> Result<()> {
         let mut inner = self.inner.lock().unwrap();
         if inner.has_bound {

--- a/src/libos/crates/host-socket/src/stream/states/listen.rs
+++ b/src/libos/crates/host-socket/src/stream/states/listen.rs
@@ -134,12 +134,45 @@ impl<A: Addr + 'static, R: Runtime> ListenerStream<A, R> {
         &self.common
     }
 
-    pub fn cancel_requests(&self) {
-        let io_uring = self.common.io_uring();
-        let inner = self.inner.lock().unwrap();
-        for entry in inner.backlog.entries.iter() {
-            if let Entry::Pending { io_handle } = entry {
-                unsafe { io_uring.cancel(io_handle) };
+    pub async fn cancel_accept_requests(&self) {
+        {
+            let io_uring = self.common.io_uring();
+            let inner = self.inner.lock().unwrap();
+            for entry in inner.backlog.entries.iter() {
+                if let Entry::Pending { io_handle } = entry {
+                    unsafe { io_uring.cancel(io_handle) };
+                }
+            }
+        }
+
+        // wait for all the cancel requests to complete
+        let poller = Poller::new();
+        let mask = Events::ERR | Events::IN;
+        self.common.pollee().connect_poller(mask, &poller);
+
+        loop {
+            let pending_entry_exists = {
+                let inner = self.inner.lock().unwrap();
+                inner
+                    .backlog
+                    .entries
+                    .iter()
+                    .find(|entry| match entry {
+                        Entry::Pending { .. } => true,
+                        _ => false,
+                    })
+                    .is_some()
+            };
+
+            if pending_entry_exists {
+                let mut timeout = Some(Duration::from_secs(20));
+                let ret = poller.wait_timeout(timeout.as_mut()).await;
+                if let Err(e) = ret {
+                    warn!("cancel wait error = {:?}", e.errno());
+                    continue;
+                }
+            } else {
+                return;
             }
         }
     }
@@ -304,8 +337,10 @@ impl<A: Addr> Backlog<A> {
                     // TODO: throw fatal errors to the upper layer.
                     let errno = Errno::from(-retval as u32);
                     log::error!("Accept error: errno = {}", errno);
-                    //inner.fatal = Some(errno);
-                    //stream.common.pollee().add_events(Events::ERR);
+
+                    // When canceling request, a poller might be waiting for this to return.
+                    inner.fatal = Some(errno);
+                    stream.common.pollee().add_events(Events::ERR);
 
                     inner.backlog.entries[entry_idx] = Entry::Free;
                     inner.backlog.num_free += 1;

--- a/src/libos/crates/host-socket/src/stream/states/listen.rs
+++ b/src/libos/crates/host-socket/src/stream/states/listen.rs
@@ -143,6 +143,22 @@ impl<A: Addr + 'static, R: Runtime> ListenerStream<A, R> {
             }
         }
     }
+
+    pub fn shutdown(&self, how: Shutdown) -> Result<()> {
+        if how == Shutdown::Both {
+            self.common.host_shutdown(Shutdown::Both)?;
+            self.common
+                .pollee()
+                .add_events(Events::IN | Events::OUT | Events::HUP);
+        } else if how.should_shut_read() {
+            self.common.host_shutdown(Shutdown::Read)?;
+            self.common.pollee().add_events(Events::IN);
+        } else if how.should_shut_write() {
+            self.common.host_shutdown(Shutdown::Write)?;
+            self.common.pollee().add_events(Events::OUT);
+        }
+        Ok(())
+    }
 }
 
 impl<A: Addr + 'static, R: Runtime> std::fmt::Debug for ListenerStream<A, R> {

--- a/src/libos/crates/sgx-untrusted-alloc/src/box_.rs
+++ b/src/libos/crates/sgx-untrusted-alloc/src/box_.rs
@@ -1,4 +1,5 @@
 use crate::untrusted_allocator::Allocator;
+use std::fmt::Debug;
 use std::mem::{align_of, size_of};
 use std::ops::{Deref, DerefMut};
 use std::ptr::NonNull;
@@ -16,6 +17,17 @@ use crate::MaybeUntrusted;
 /// measure to avoid potential misuses.
 pub struct UntrustedBox<T: ?Sized> {
     ptr: NonNull<T>,
+}
+
+impl<T> Debug for UntrustedBox<T>
+where
+    T: ?Sized + Debug,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Untrusted T")
+            .field("T", unsafe { &self.ptr.as_ref() })
+            .finish()
+    }
 }
 
 impl<T: MaybeUntrusted> UntrustedBox<T> {

--- a/src/libos/src/config.rs
+++ b/src/libos/src/config.rs
@@ -193,7 +193,6 @@ impl Config {
             if let Some(input_socks) = &input.untrusted_unix_socks {
                 let mut untrusted_socks = Vec::new();
                 for sock in input_socks {
-                    info!("sock = {:?}", sock);
                     let untrusted_sock = ConfigUntrustedUnixSock {
                         host: Path::new(&sock.host).to_path_buf(),
                         libos: Path::new(&sock.libos).to_path_buf(),

--- a/src/libos/src/fs/file_handle.rs
+++ b/src/libos/src/fs/file_handle.rs
@@ -199,6 +199,13 @@ impl FileHandle {
         }
     }
 
+    pub fn as_socket_file_arc(&self) -> Option<&Arc<SocketFile>> {
+        match &self.0.file {
+            AnyFile::Socket(socket_file) => Some(socket_file),
+            _ => None,
+        }
+    }
+
     // Returns the underlying epoll file if it is one.
     pub fn as_epoll_file(&self) -> Option<&EpollFile> {
         match &self.0.file {

--- a/src/libos/src/fs/file_ops/close.rs
+++ b/src/libos/src/fs/file_ops/close.rs
@@ -18,6 +18,15 @@ pub async fn do_close(fd: FileDesc) -> Result<()> {
     if let Some(disk_file) = file_ref.as_disk_file() {
         let _ = disk_file.flush().await;
     }
+    // Make sure the socket async request completes so that when removing from the file table,
+    // the host socket is actually dropped and closed.
+    if let Some(socket_file) = file_ref.as_socket_file_arc() {
+        let ref_count = Arc::strong_count(socket_file);
+        if ref_count == 2 {
+            // One here, one in the file table.
+            let _ = socket_file.close().await;
+        }
+    }
 
     current.close_file(fd)?;
     Ok(())

--- a/src/libos/src/net/socket_file.rs
+++ b/src/libos/src/net/socket_file.rs
@@ -382,30 +382,10 @@ impl SocketFile {
         flags: SendFlags,
     ) -> Result<usize> {
         let res = match &self.socket {
-            AnySocket::Ipv4Stream(ipv4_stream) => {
-                if addr.is_some() {
-                    return_errno!(EISCONN, "addr should be none");
-                }
-                ipv4_stream.sendmsg(bufs, flags).await
-            }
-            AnySocket::Ipv6Stream(ipv6_stream) => {
-                if addr.is_some() {
-                    return_errno!(EISCONN, "addr should be none");
-                }
-                ipv6_stream.sendmsg(bufs, flags).await
-            }
-            AnySocket::UnixStream(unix_stream) => {
-                if addr.is_some() {
-                    return_errno!(EISCONN, "addr should be none");
-                }
-                unix_stream.sendmsg(bufs, flags).await
-            }
-            AnySocket::TrustedUDS(trusted_stream) => {
-                if addr.is_some() {
-                    return_errno!(EISCONN, "addr should be none");
-                }
-                trusted_stream.sendmsg(bufs, flags).await
-            }
+            AnySocket::Ipv4Stream(ipv4_stream) => ipv4_stream.sendmsg(bufs, flags).await,
+            AnySocket::Ipv6Stream(ipv6_stream) => ipv6_stream.sendmsg(bufs, flags).await,
+            AnySocket::UnixStream(unix_stream) => unix_stream.sendmsg(bufs, flags).await,
+            AnySocket::TrustedUDS(trusted_stream) => trusted_stream.sendmsg(bufs, flags).await,
             AnySocket::Ipv4Datagram(ipv4_datagram) => {
                 let ip_addr = if let Some(addr) = addr.as_ref() {
                     Some(addr.to_ipv4()?)

--- a/src/libos/src/net/socket_file.rs
+++ b/src/libos/src/net/socket_file.rs
@@ -337,20 +337,20 @@ impl SocketFile {
         // TODO: support msg_flags and msg_control
         Ok(match &self.socket {
             AnySocket::Ipv4Stream(ipv4_stream) => {
-                let bytes_recv = ipv4_stream.recvmsg(bufs, flags).await?;
-                (bytes_recv, None)
+                let (bytes_recv, addr_recv) = ipv4_stream.recvmsg(bufs, flags).await?;
+                (bytes_recv, addr_recv.map(|addr| AnyAddr::Ipv4(addr)))
             }
             AnySocket::Ipv6Stream(ipv6_stream) => {
-                let bytes_recv = ipv6_stream.recvmsg(bufs, flags).await?;
-                (bytes_recv, None)
+                let (bytes_recv, addr_recv) = ipv6_stream.recvmsg(bufs, flags).await?;
+                (bytes_recv, addr_recv.map(|addr| AnyAddr::Ipv6(addr)))
             }
             AnySocket::UnixStream(unix_stream) => {
-                let bytes_recv = unix_stream.recvmsg(bufs, flags).await?;
-                (bytes_recv, None)
+                let (bytes_recv, addr_recv) = unix_stream.recvmsg(bufs, flags).await?;
+                (bytes_recv, addr_recv.map(|addr| AnyAddr::Unix(addr)))
             }
             AnySocket::TrustedUDS(trusted_stream) => {
-                let bytes_recv = trusted_stream.recvmsg(bufs, flags).await?;
-                (bytes_recv, None)
+                let (bytes_recv, addr_recv) = trusted_stream.recvmsg(bufs, flags).await?;
+                (bytes_recv, addr_recv.map(|addr| AnyAddr::Unix(addr)))
             }
             AnySocket::Ipv4Datagram(ipv4_datagram) => {
                 let (bytes_recv, addr_recv) = ipv4_datagram.recvmsg(bufs, flags).await?;

--- a/src/libos/src/net/socket_file.rs
+++ b/src/libos/src/net/socket_file.rs
@@ -357,7 +357,8 @@ impl SocketFile {
         buf: &mut [u8],
         flags: RecvFlags,
     ) -> Result<(usize, Option<AnyAddr>)> {
-        self.recvmsg(&mut [buf], flags, None).await
+        let (bytes_recv, addr_recv, _) = self.recvmsg(&mut [buf], flags, None).await?;
+        Ok((bytes_recv, addr_recv))
     }
 
     pub async fn recvmsg(
@@ -365,36 +366,51 @@ impl SocketFile {
         bufs: &mut [&mut [u8]],
         flags: RecvFlags,
         control: Option<&mut [u8]>,
-    ) -> Result<(usize, Option<AnyAddr>)> {
+    ) -> Result<(usize, Option<AnyAddr>, i32)> {
         // TODO: support msg_flags and msg_control
         Ok(match &self.socket {
             AnySocket::Ipv4Stream(ipv4_stream) => {
                 let (bytes_recv, addr_recv) = ipv4_stream.recvmsg(bufs, flags, control).await?;
-                (bytes_recv, addr_recv.map(|addr| AnyAddr::Ipv4(addr)))
+                (bytes_recv, addr_recv.map(|addr| AnyAddr::Ipv4(addr)), 0)
             }
             AnySocket::Ipv6Stream(ipv6_stream) => {
                 let (bytes_recv, addr_recv) = ipv6_stream.recvmsg(bufs, flags, control).await?;
-                (bytes_recv, addr_recv.map(|addr| AnyAddr::Ipv6(addr)))
+                (bytes_recv, addr_recv.map(|addr| AnyAddr::Ipv6(addr)), 0)
             }
             AnySocket::UnixStream(unix_stream) => {
                 let (bytes_recv, addr_recv) = unix_stream.recvmsg(bufs, flags, control).await?;
-                (bytes_recv, addr_recv.map(|addr| AnyAddr::Unix(addr)))
+                (bytes_recv, addr_recv.map(|addr| AnyAddr::Unix(addr)), 0)
             }
             AnySocket::TrustedUDS(trusted_stream) => {
                 let (bytes_recv, addr_recv) = trusted_stream.recvmsg(bufs, flags, control).await?;
-                (bytes_recv, addr_recv.map(|addr| AnyAddr::Unix(addr)))
+                (bytes_recv, addr_recv.map(|addr| AnyAddr::Unix(addr)), 0)
             }
             AnySocket::Ipv4Datagram(ipv4_datagram) => {
-                let (bytes_recv, addr_recv) = ipv4_datagram.recvmsg(bufs, flags, control).await?;
-                (bytes_recv, addr_recv.map(|addr| AnyAddr::Ipv4(addr)))
+                let (bytes_recv, addr_recv, msg_flags) =
+                    ipv4_datagram.recvmsg(bufs, flags, control).await?;
+                (
+                    bytes_recv,
+                    addr_recv.map(|addr| AnyAddr::Ipv4(addr)),
+                    msg_flags,
+                )
             }
             AnySocket::Ipv6Datagram(ipv6_datagram) => {
-                let (bytes_recv, addr_recv) = ipv6_datagram.recvmsg(bufs, flags, control).await?;
-                (bytes_recv, addr_recv.map(|addr| AnyAddr::Ipv6(addr)))
+                let (bytes_recv, addr_recv, msg_flags) =
+                    ipv6_datagram.recvmsg(bufs, flags, control).await?;
+                (
+                    bytes_recv,
+                    addr_recv.map(|addr| AnyAddr::Ipv6(addr)),
+                    msg_flags,
+                )
             }
             AnySocket::UnixDatagram(unix_datagram) => {
-                let (bytes_recv, addr_recv) = unix_datagram.recvmsg(bufs, flags, control).await?;
-                (bytes_recv, addr_recv.map(|addr| AnyAddr::Unix(addr)))
+                let (bytes_recv, addr_recv, msg_flags) =
+                    unix_datagram.recvmsg(bufs, flags, control).await?;
+                (
+                    bytes_recv,
+                    addr_recv.map(|addr| AnyAddr::Unix(addr)),
+                    msg_flags,
+                )
             }
             _ => {
                 return_errno!(EINVAL, "recvfrom is not supported");

--- a/src/libos/src/net/socket_file.rs
+++ b/src/libos/src/net/socket_file.rs
@@ -385,15 +385,15 @@ impl SocketFile {
             }
             AnySocket::Ipv4Datagram(ipv4_datagram) => {
                 let (bytes_recv, addr_recv) = ipv4_datagram.recvmsg(bufs, flags).await?;
-                (bytes_recv, Some(AnyAddr::Ipv4(addr_recv)))
+                (bytes_recv, addr_recv.map(|addr| AnyAddr::Ipv4(addr)))
             }
             AnySocket::Ipv6Datagram(ipv6_datagram) => {
                 let (bytes_recv, addr_recv) = ipv6_datagram.recvmsg(bufs, flags).await?;
-                (bytes_recv, Some(AnyAddr::Ipv6(addr_recv)))
+                (bytes_recv, addr_recv.map(|addr| AnyAddr::Ipv6(addr)))
             }
             AnySocket::UnixDatagram(unix_datagram) => {
                 let (bytes_recv, addr_recv) = unix_datagram.recvmsg(bufs, flags).await?;
-                (bytes_recv, Some(AnyAddr::Unix(addr_recv)))
+                (bytes_recv, addr_recv.map(|addr| AnyAddr::Unix(addr)))
             }
             _ => {
                 return_errno!(EINVAL, "recvfrom is not supported");
@@ -492,6 +492,8 @@ impl SocketFile {
             AnySocket::Ipv4Stream(ipv4_stream) => ipv4_stream.shutdown(how).await,
             AnySocket::Ipv6Stream(ipv6_stream) => ipv6_stream.shutdown(how).await,
             AnySocket::UnixStream(unix_stream) => unix_stream.shutdown(how).await,
+            AnySocket::Ipv4Datagram(ipv4_datagram) => ipv4_datagram.shutdown(how).await,
+            AnySocket::Ipv6Datagram(ipv6_datagram) => ipv6_datagram.shutdown(how).await,
             _ => {
                 return_errno!(EINVAL, "shutdown is not supported");
             }

--- a/src/libos/src/net/socket_file.rs
+++ b/src/libos/src/net/socket_file.rs
@@ -357,42 +357,43 @@ impl SocketFile {
         buf: &mut [u8],
         flags: RecvFlags,
     ) -> Result<(usize, Option<AnyAddr>)> {
-        self.recvmsg(&mut [buf], flags).await
+        self.recvmsg(&mut [buf], flags, None).await
     }
 
     pub async fn recvmsg(
         &self,
         bufs: &mut [&mut [u8]],
         flags: RecvFlags,
+        control: Option<&mut [u8]>,
     ) -> Result<(usize, Option<AnyAddr>)> {
         // TODO: support msg_flags and msg_control
         Ok(match &self.socket {
             AnySocket::Ipv4Stream(ipv4_stream) => {
-                let (bytes_recv, addr_recv) = ipv4_stream.recvmsg(bufs, flags).await?;
+                let (bytes_recv, addr_recv) = ipv4_stream.recvmsg(bufs, flags, control).await?;
                 (bytes_recv, addr_recv.map(|addr| AnyAddr::Ipv4(addr)))
             }
             AnySocket::Ipv6Stream(ipv6_stream) => {
-                let (bytes_recv, addr_recv) = ipv6_stream.recvmsg(bufs, flags).await?;
+                let (bytes_recv, addr_recv) = ipv6_stream.recvmsg(bufs, flags, control).await?;
                 (bytes_recv, addr_recv.map(|addr| AnyAddr::Ipv6(addr)))
             }
             AnySocket::UnixStream(unix_stream) => {
-                let (bytes_recv, addr_recv) = unix_stream.recvmsg(bufs, flags).await?;
+                let (bytes_recv, addr_recv) = unix_stream.recvmsg(bufs, flags, control).await?;
                 (bytes_recv, addr_recv.map(|addr| AnyAddr::Unix(addr)))
             }
             AnySocket::TrustedUDS(trusted_stream) => {
-                let (bytes_recv, addr_recv) = trusted_stream.recvmsg(bufs, flags).await?;
+                let (bytes_recv, addr_recv) = trusted_stream.recvmsg(bufs, flags, control).await?;
                 (bytes_recv, addr_recv.map(|addr| AnyAddr::Unix(addr)))
             }
             AnySocket::Ipv4Datagram(ipv4_datagram) => {
-                let (bytes_recv, addr_recv) = ipv4_datagram.recvmsg(bufs, flags).await?;
+                let (bytes_recv, addr_recv) = ipv4_datagram.recvmsg(bufs, flags, control).await?;
                 (bytes_recv, addr_recv.map(|addr| AnyAddr::Ipv4(addr)))
             }
             AnySocket::Ipv6Datagram(ipv6_datagram) => {
-                let (bytes_recv, addr_recv) = ipv6_datagram.recvmsg(bufs, flags).await?;
+                let (bytes_recv, addr_recv) = ipv6_datagram.recvmsg(bufs, flags, control).await?;
                 (bytes_recv, addr_recv.map(|addr| AnyAddr::Ipv6(addr)))
             }
             AnySocket::UnixDatagram(unix_datagram) => {
-                let (bytes_recv, addr_recv) = unix_datagram.recvmsg(bufs, flags).await?;
+                let (bytes_recv, addr_recv) = unix_datagram.recvmsg(bufs, flags, control).await?;
                 (bytes_recv, addr_recv.map(|addr| AnyAddr::Unix(addr)))
             }
             _ => {
@@ -407,7 +408,7 @@ impl SocketFile {
         addr: Option<AnyAddr>,
         flags: SendFlags,
     ) -> Result<usize> {
-        self.sendmsg(&[buf], addr, flags).await
+        self.sendmsg(&[buf], addr, flags, None).await
     }
 
     pub async fn sendmsg(
@@ -415,6 +416,7 @@ impl SocketFile {
         bufs: &[&[u8]],
         addr: Option<AnyAddr>,
         flags: SendFlags,
+        control: Option<&[u8]>,
     ) -> Result<usize> {
         let res = match &self.socket {
             AnySocket::Ipv4Stream(ipv4_stream) => ipv4_stream.sendmsg(bufs, flags).await,
@@ -427,7 +429,7 @@ impl SocketFile {
                 } else {
                     None
                 };
-                ipv4_datagram.sendmsg(bufs, ip_addr, flags).await
+                ipv4_datagram.sendmsg(bufs, ip_addr, flags, control).await
             }
             AnySocket::Ipv6Datagram(ipv6_datagram) => {
                 let ip_addr = if let Some(addr) = addr.as_ref() {
@@ -435,7 +437,7 @@ impl SocketFile {
                 } else {
                     None
                 };
-                ipv6_datagram.sendmsg(bufs, ip_addr, flags).await
+                ipv6_datagram.sendmsg(bufs, ip_addr, flags, control).await
             }
             AnySocket::UnixDatagram(unix_datagram) => {
                 let unix_addr = if let Some(addr) = addr.as_ref() {
@@ -443,7 +445,7 @@ impl SocketFile {
                 } else {
                     None
                 };
-                unix_datagram.sendmsg(bufs, unix_addr, flags).await
+                unix_datagram.sendmsg(bufs, unix_addr, flags, control).await
             }
             _ => {
                 return_errno!(EINVAL, "sendmsg is not supported");

--- a/src/libos/src/net/socket_file.rs
+++ b/src/libos/src/net/socket_file.rs
@@ -443,14 +443,22 @@ impl SocketFile {
         })
     }
 
-    pub fn shutdown(&self, how: Shutdown) -> Result<()> {
+    pub async fn shutdown(&self, how: Shutdown) -> Result<()> {
         match &self.socket {
-            AnySocket::Ipv4Stream(ipv4_stream) => ipv4_stream.shutdown(how),
-            AnySocket::Ipv6Stream(ipv6_stream) => ipv6_stream.shutdown(how),
-            AnySocket::UnixStream(unix_stream) => unix_stream.shutdown(how),
+            AnySocket::Ipv4Stream(ipv4_stream) => ipv4_stream.shutdown(how).await,
+            AnySocket::Ipv6Stream(ipv6_stream) => ipv6_stream.shutdown(how).await,
+            AnySocket::UnixStream(unix_stream) => unix_stream.shutdown(how).await,
             _ => {
                 return_errno!(EINVAL, "shutdown is not supported");
             }
+        }
+    }
+
+    pub async fn close(&self) -> Result<()> {
+        match &self.socket {
+            AnySocket::Ipv4Stream(ipv4_stream) => ipv4_stream.close().await,
+            AnySocket::Ipv6Stream(ipv6_stream) => ipv6_stream.close().await,
+            _ => Ok(()),
         }
     }
 }

--- a/src/libos/src/net/socket_file.rs
+++ b/src/libos/src/net/socket_file.rs
@@ -357,7 +357,7 @@ impl SocketFile {
         buf: &mut [u8],
         flags: RecvFlags,
     ) -> Result<(usize, Option<AnyAddr>)> {
-        let (bytes_recv, addr_recv, _) = self.recvmsg(&mut [buf], flags, None).await?;
+        let (bytes_recv, addr_recv, _, _) = self.recvmsg(&mut [buf], flags, None).await?;
         Ok((bytes_recv, addr_recv))
     }
 
@@ -366,50 +366,53 @@ impl SocketFile {
         bufs: &mut [&mut [u8]],
         flags: RecvFlags,
         control: Option<&mut [u8]>,
-    ) -> Result<(usize, Option<AnyAddr>, i32)> {
+    ) -> Result<(usize, Option<AnyAddr>, i32, usize)> {
         // TODO: support msg_flags and msg_control
         Ok(match &self.socket {
             AnySocket::Ipv4Stream(ipv4_stream) => {
                 let (bytes_recv, addr_recv) = ipv4_stream.recvmsg(bufs, flags, control).await?;
-                (bytes_recv, addr_recv.map(|addr| AnyAddr::Ipv4(addr)), 0)
+                (bytes_recv, addr_recv.map(|addr| AnyAddr::Ipv4(addr)), 0, 0)
             }
             AnySocket::Ipv6Stream(ipv6_stream) => {
                 let (bytes_recv, addr_recv) = ipv6_stream.recvmsg(bufs, flags, control).await?;
-                (bytes_recv, addr_recv.map(|addr| AnyAddr::Ipv6(addr)), 0)
+                (bytes_recv, addr_recv.map(|addr| AnyAddr::Ipv6(addr)), 0, 0)
             }
             AnySocket::UnixStream(unix_stream) => {
                 let (bytes_recv, addr_recv) = unix_stream.recvmsg(bufs, flags, control).await?;
-                (bytes_recv, addr_recv.map(|addr| AnyAddr::Unix(addr)), 0)
+                (bytes_recv, addr_recv.map(|addr| AnyAddr::Unix(addr)), 0, 0)
             }
             AnySocket::TrustedUDS(trusted_stream) => {
                 let (bytes_recv, addr_recv) = trusted_stream.recvmsg(bufs, flags, control).await?;
-                (bytes_recv, addr_recv.map(|addr| AnyAddr::Unix(addr)), 0)
+                (bytes_recv, addr_recv.map(|addr| AnyAddr::Unix(addr)), 0, 0)
             }
             AnySocket::Ipv4Datagram(ipv4_datagram) => {
-                let (bytes_recv, addr_recv, msg_flags) =
+                let (bytes_recv, addr_recv, msg_flags, msg_controllen) =
                     ipv4_datagram.recvmsg(bufs, flags, control).await?;
                 (
                     bytes_recv,
                     addr_recv.map(|addr| AnyAddr::Ipv4(addr)),
                     msg_flags,
+                    msg_controllen,
                 )
             }
             AnySocket::Ipv6Datagram(ipv6_datagram) => {
-                let (bytes_recv, addr_recv, msg_flags) =
+                let (bytes_recv, addr_recv, msg_flags, msg_controllen) =
                     ipv6_datagram.recvmsg(bufs, flags, control).await?;
                 (
                     bytes_recv,
                     addr_recv.map(|addr| AnyAddr::Ipv6(addr)),
                     msg_flags,
+                    msg_controllen,
                 )
             }
             AnySocket::UnixDatagram(unix_datagram) => {
-                let (bytes_recv, addr_recv, msg_flags) =
+                let (bytes_recv, addr_recv, msg_flags, msg_controllen) =
                     unix_datagram.recvmsg(bufs, flags, control).await?;
                 (
                     bytes_recv,
                     addr_recv.map(|addr| AnyAddr::Unix(addr)),
                     msg_flags,
+                    msg_controllen,
                 )
             }
             _ => {

--- a/src/libos/src/net/sockopt.rs
+++ b/src/libos/src/net/sockopt.rs
@@ -1,6 +1,9 @@
+use async_io::socket::{GetRecvTimeoutCmd, GetSendTimeoutCmd};
 use host_socket::sockopt::{
     GetAcceptConnCmd, GetDomainCmd, GetPeerNameCmd, GetSockOptRawCmd, GetTypeCmd,
 };
+use libc::timeval;
+use std::time::Duration;
 
 use crate::prelude::*;
 
@@ -42,6 +45,28 @@ impl GetOutputAsBytes for GetTypeCmd {
     fn get_output_as_bytes(&self) -> Option<&[u8]> {
         self.output().map(|val_ref| unsafe {
             std::slice::from_raw_parts(val_ref as *const _ as *const u8, std::mem::size_of::<i32>())
+        })
+    }
+}
+
+impl GetOutputAsBytes for GetRecvTimeoutCmd {
+    fn get_output_as_bytes(&self) -> Option<&[u8]> {
+        self.output().map(|val_ref| unsafe {
+            std::slice::from_raw_parts(
+                val_ref as *const _ as *const u8,
+                std::mem::size_of::<timeval>(),
+            )
+        })
+    }
+}
+
+impl GetOutputAsBytes for GetSendTimeoutCmd {
+    fn get_output_as_bytes(&self) -> Option<&[u8]> {
+        self.output().map(|val_ref| unsafe {
+            std::slice::from_raw_parts(
+                val_ref as *const _ as *const u8,
+                std::mem::size_of::<timeval>(),
+            )
         })
     }
 }

--- a/src/libos/src/net/syscalls.rs
+++ b/src/libos/src/net/syscalls.rs
@@ -258,6 +258,9 @@ pub async fn do_recvfrom(
         if let Some(addr_recv) = addr_recv {
             let (c_addr_storage, c_addr_len) = addr_recv.to_c_storage();
             copy_sock_addr_to_user(c_addr_storage, c_addr_len, addr_mut, addr_len_mut);
+        } else {
+            // If addr_recv is not filled, set addr_len to 0
+            *addr_len_mut = 0;
         }
     }
     Ok(bytes_recv as _)

--- a/src/libos/src/net/syscalls.rs
+++ b/src/libos/src/net/syscalls.rs
@@ -1,5 +1,6 @@
 use std::convert::TryFrom;
 use std::mem::MaybeUninit;
+use std::ptr::{self};
 use std::time::Duration;
 
 use async_io::ioctl::IoctlCmd;
@@ -300,7 +301,7 @@ pub async fn do_recvmsg(fd: c_int, msg_mut_ptr: *mut libc::msghdr, flags: c_int)
     let (mut msg, mut addr, mut control, mut bufs) = extract_msghdr_mut_from_user(msg_mut_ptr)?;
     let flags = RecvFlags::from_bits_truncate(flags);
 
-    let (bytes_recv, recv_addr, msg_flags) =
+    let (bytes_recv, recv_addr, msg_flags, msg_controllen) =
         socket_file.recvmsg(&mut bufs[..], flags, control).await?;
 
     if let Some(addr) = addr {
@@ -310,8 +311,12 @@ pub async fn do_recvmsg(fd: c_int, msg_mut_ptr: *mut libc::msghdr, flags: c_int)
         }
     }
 
-    // update msghdr msg_flags
+    // update msghdr
     msg.msg_flags = msg_flags;
+    msg.msg_controllen = msg_controllen;
+    if msg_controllen == 0 {
+        msg.msg_control = ptr::null_mut();
+    }
 
     Ok(bytes_recv as isize)
 }

--- a/src/libos/src/net/syscalls.rs
+++ b/src/libos/src/net/syscalls.rs
@@ -600,8 +600,10 @@ fn new_setsockopt_cmd(level: i32, optname: i32, optval: &[u8]) -> Result<Box<dyn
                 } else {
                     (*timeout).tv_sec
                 };
-                if ((*timeout).tv_usec as u32).checked_mul(1000).is_none() {
-                    return_errno!(EDOM, "time struct conversion overflow");
+
+                let usec = (*timeout).tv_usec;
+                if usec < 0 || usec > 1000000 || (usec as u32).checked_mul(1000).is_none() {
+                    return_errno!(EDOM, "time struct value is invalid");
                 }
                 Duration::new(secs as u64, (*timeout).tv_usec as u32 * 1000)
             };
@@ -621,10 +623,12 @@ fn new_setsockopt_cmd(level: i32, optname: i32, optval: &[u8]) -> Result<Box<dyn
                 } else {
                     (*timeout).tv_sec
                 };
-                if ((*timeout).tv_usec as u32).checked_mul(1000).is_none() {
-                    return_errno!(EDOM, "time struct conversion overflow");
+
+                let usec = (*timeout).tv_usec;
+                if usec < 0 || usec > 1000000 || (usec as u32).checked_mul(1000).is_none() {
+                    return_errno!(EDOM, "time struct value is invalid");
                 }
-                Duration::new(secs as u64, (*timeout).tv_usec as u32 * 1000)
+                Duration::new(secs as u64, usec as u32 * 1000)
             };
             trace!("send timeout = {:?}", timeout);
             Box::new(SetSendTimeoutCmd::new(timeout))

--- a/src/libos/src/net/syscalls.rs
+++ b/src/libos/src/net/syscalls.rs
@@ -415,6 +415,13 @@ pub async fn do_getsockopt(
     let optlen = *optlen_mut;
     let optval_mut = from_user::make_mut_slice(optval as *mut u8, optlen as usize)?;
 
+    // Man getsockopt:
+    // If the size of the option value is greater than option_len, the value stored in the object pointed to by the option_value argument will be silently truncated.
+    // Thus if the optlen is 0, nothing is returned to optval. We can just return here.
+    if optlen == 0 || optval_mut.len() == 0 {
+        return Ok(0);
+    }
+
     let mut cmd = new_getsockopt_cmd(level, optname, optlen)?;
     socket_file.ioctl(cmd.as_mut()).await?;
     let src_optval = get_optval(cmd.as_ref())?;

--- a/src/libos/src/net/syscalls.rs
+++ b/src/libos/src/net/syscalls.rs
@@ -1,7 +1,11 @@
 use std::convert::TryFrom;
 use std::mem::MaybeUninit;
+use std::time::Duration;
 
 use async_io::ioctl::IoctlCmd;
+use async_io::socket::{
+    GetRecvTimeoutCmd, GetSendTimeoutCmd, SetRecvTimeoutCmd, SetSendTimeoutCmd,
+};
 use async_io::socket::{RecvFlags, SendFlags, Shutdown, Type};
 use host_socket::sockopt::{
     GetAcceptConnCmd, GetDomainCmd, GetPeerNameCmd, GetSockOptRawCmd, GetTypeCmd, SetSockOptRawCmd,
@@ -545,6 +549,8 @@ fn new_getsockopt_cmd(level: i32, optname: i32, optlen: u32) -> Result<Box<dyn I
         SockOptName::SO_DOMAIN => Box::new(GetDomainCmd::new(())),
         SockOptName::SO_PEERNAME => Box::new(GetPeerNameCmd::new(())),
         SockOptName::SO_TYPE => Box::new(GetTypeCmd::new(())),
+        SockOptName::SO_RCVTIMEO_OLD => Box::new(GetRecvTimeoutCmd::new(())),
+        SockOptName::SO_SNDTIMEO_OLD => Box::new(GetSendTimeoutCmd::new(())),
         SockOptName::SO_CNX_ADVICE => return_errno!(ENOPROTOOPT, "it's a write-only option"),
         _ => Box::new(GetSockOptRawCmd::new(level, optname, optlen)),
     })
@@ -572,6 +578,48 @@ fn new_setsockopt_cmd(level: i32, optname: i32, optval: &[u8]) -> Result<Box<dyn
         | SockOptName::SO_INCOMING_NAPI_ID
         | SockOptName::SO_COOKIE
         | SockOptName::SO_PEERGROUPS => return_errno!(ENOPROTOOPT, "it's a read-only option"),
+        SockOptName::SO_RCVTIMEO_OLD => {
+            let mut timeout: *const libc::timeval = std::ptr::null();
+            if optval.len() >= std::mem::size_of::<libc::timeval>() {
+                timeout = optval as *const _ as *const libc::timeval;
+            } else {
+                return_errno!(EINVAL, "invalid timeout option");
+            }
+            let timeout = unsafe {
+                let secs = if (*timeout).tv_sec < 0 {
+                    0
+                } else {
+                    (*timeout).tv_sec
+                };
+                if ((*timeout).tv_usec as u32).checked_mul(1000).is_none() {
+                    return_errno!(EDOM, "time struct conversion overflow");
+                }
+                Duration::new(secs as u64, (*timeout).tv_usec as u32 * 1000)
+            };
+            trace!("recv timeout = {:?}", timeout);
+            Box::new(SetRecvTimeoutCmd::new(timeout))
+        }
+        SockOptName::SO_SNDTIMEO_OLD => {
+            let mut timeout: *const libc::timeval = std::ptr::null();
+            if optval.len() >= std::mem::size_of::<libc::timeval>() {
+                timeout = optval as *const _ as *const libc::timeval;
+            } else {
+                return_errno!(EINVAL, "invalid timeout option");
+            }
+            let timeout = unsafe {
+                let secs = if (*timeout).tv_sec < 0 {
+                    0
+                } else {
+                    (*timeout).tv_sec
+                };
+                if ((*timeout).tv_usec as u32).checked_mul(1000).is_none() {
+                    return_errno!(EDOM, "time struct conversion overflow");
+                }
+                Duration::new(secs as u64, (*timeout).tv_usec as u32 * 1000)
+            };
+            trace!("send timeout = {:?}", timeout);
+            Box::new(SetSendTimeoutCmd::new(timeout))
+        }
         _ => Box::new(SetSockOptRawCmd::new(level, optname, optval)),
     })
 }
@@ -591,6 +639,12 @@ fn get_optval(cmd: &dyn IoctlCmd) -> Result<&[u8]> {
             cmd.get_output_as_bytes()
         },
         cmd : GetSockOptRawCmd => {
+            cmd.get_output_as_bytes()
+        },
+        cmd : GetRecvTimeoutCmd => {
+            cmd.get_output_as_bytes()
+        },
+        cmd : GetSendTimeoutCmd => {
             cmd.get_output_as_bytes()
         },
         _ => {

--- a/src/libos/src/net/syscalls.rs
+++ b/src/libos/src/net/syscalls.rs
@@ -468,7 +468,7 @@ pub async fn do_shutdown(fd: c_int, how: c_int) -> Result<isize> {
 
     let how = Shutdown::from_c(how as _)?;
 
-    socket_file.shutdown(how)?;
+    socket_file.shutdown(how).await?;
     Ok(0)
 }
 

--- a/src/libos/src/net/syscalls.rs
+++ b/src/libos/src/net/syscalls.rs
@@ -300,7 +300,8 @@ pub async fn do_recvmsg(fd: c_int, msg_mut_ptr: *mut libc::msghdr, flags: c_int)
     let (mut msg, mut addr, mut control, mut bufs) = extract_msghdr_mut_from_user(msg_mut_ptr)?;
     let flags = RecvFlags::from_bits_truncate(flags);
 
-    let (bytes_recv, recv_addr) = socket_file.recvmsg(&mut bufs[..], flags, control).await?;
+    let (bytes_recv, recv_addr, msg_flags) =
+        socket_file.recvmsg(&mut bufs[..], flags, control).await?;
 
     if let Some(addr) = addr {
         if let Some(recv_addr) = recv_addr {
@@ -309,8 +310,8 @@ pub async fn do_recvmsg(fd: c_int, msg_mut_ptr: *mut libc::msghdr, flags: c_int)
         }
     }
 
-    // Clear msghdr flags to 0 after recvmsg
-    msg.msg_flags = 0;
+    // update msghdr msg_flags
+    msg.msg_flags = msg_flags;
 
     Ok(bytes_recv as isize)
 }

--- a/src/libos/src/net/syscalls.rs
+++ b/src/libos/src/net/syscalls.rs
@@ -277,11 +277,11 @@ pub async fn do_sendmsg(fd: c_int, msg_ptr: *const libc::msghdr, flags: c_int) -
         .as_socket_file()
         .ok_or_else(|| errno!(ENOTSOCK, "not a socket"))?;
 
-    let (addr, bufs) = extract_msghdr_from_user(msg_ptr)?;
+    let (addr, bufs, control) = extract_msghdr_from_user(msg_ptr)?;
     let flags = SendFlags::from_bits_truncate(flags);
 
     socket_file
-        .sendmsg(&bufs[..], addr, flags)
+        .sendmsg(&bufs[..], addr, flags, control)
         .await
         .map(|bytes_send| bytes_send as isize)
 }
@@ -297,10 +297,10 @@ pub async fn do_recvmsg(fd: c_int, msg_mut_ptr: *mut libc::msghdr, flags: c_int)
         .as_socket_file()
         .ok_or_else(|| errno!(ENOTSOCK, "not a socket"))?;
 
-    let (mut msg, mut addr, mut bufs) = extract_msghdr_mut_from_user(msg_mut_ptr)?;
+    let (mut msg, mut addr, mut control, mut bufs) = extract_msghdr_mut_from_user(msg_mut_ptr)?;
     let flags = RecvFlags::from_bits_truncate(flags);
 
-    let (bytes_recv, recv_addr) = socket_file.recvmsg(&mut bufs[..], flags).await?;
+    let (bytes_recv, recv_addr) = socket_file.recvmsg(&mut bufs[..], flags, control).await?;
 
     if let Some(addr) = addr {
         if let Some(recv_addr) = recv_addr {
@@ -337,10 +337,10 @@ pub async fn do_sendmmsg(
 
     let mut send_count = 0;
     for mmsg in (msgvec) {
-        let (addr, bufs) = extract_msghdr_from_user(&mmsg.msg_hdr)?;
+        let (addr, bufs, control) = extract_msghdr_from_user(&mmsg.msg_hdr)?;
 
         if socket_file
-            .sendmsg(&bufs[..], addr, flags)
+            .sendmsg(&bufs[..], addr, flags, control)
             .await
             .map(|bytes_send| {
                 mmsg.msg_len += bytes_send as c_uint;
@@ -670,7 +670,7 @@ fn copy_bytes_to_user(src_buf: &[u8], dst_buf: &mut [u8], dst_len: &mut u32) {
 
 fn extract_msghdr_from_user<'a>(
     msg_ptr: *const libc::msghdr,
-) -> Result<(Option<AnyAddr>, Vec<&'a [u8]>)> {
+) -> Result<(Option<AnyAddr>, Vec<&'a [u8]>, Option<&'a [u8]>)> {
     let msg = from_user::make_ref(msg_ptr)?;
 
     let msg_name = msg.msg_name;
@@ -685,6 +685,25 @@ fn extract_msghdr_from_user<'a>(
         Some(AnyAddr::from_c_storage(
             &sockaddr_storage,
             msg_namelen as _,
+        )?)
+    };
+
+    let msg_control = msg.msg_control;
+    let msg_controllen = msg.msg_controllen;
+
+    if msg_control.is_null() ^ (msg_controllen == 0) {
+        return_errno!(
+            EINVAL,
+            "message control and controllen should be both null and 0 or not"
+        );
+    }
+
+    let control = if msg_control.is_null() {
+        None
+    } else {
+        Some(from_user::make_slice(
+            msg_control as *const u8,
+            msg_controllen as _,
         )?)
     };
 
@@ -705,13 +724,14 @@ fn extract_msghdr_from_user<'a>(
         bufs
     };
 
-    Ok((name, bufs))
+    Ok((name, bufs, control))
 }
 
 fn extract_msghdr_mut_from_user<'a>(
     msg_mut_ptr: *mut libc::msghdr,
 ) -> Result<(
     &'a mut libc::msghdr,
+    Option<&'a mut [u8]>,
     Option<&'a mut [u8]>,
     Vec<&'a mut [u8]>,
 )> {
@@ -728,6 +748,25 @@ fn extract_msghdr_mut_from_user<'a>(
         Some(from_user::make_mut_slice(
             msg_name as *mut u8,
             msg_namelen as usize,
+        )?)
+    };
+
+    let msg_control = msg_mut.msg_control;
+    let msg_controllen = msg_mut.msg_controllen;
+
+    if msg_control.is_null() ^ (msg_controllen == 0) {
+        return_errno!(
+            EINVAL,
+            "message control and controllen should be both null and 0 or not"
+        );
+    }
+
+    let control = if msg_control.is_null() {
+        None
+    } else {
+        Some(from_user::make_mut_slice(
+            msg_control as *mut u8,
+            msg_controllen as usize,
         )?)
     };
 
@@ -748,5 +787,5 @@ fn extract_msghdr_mut_from_user<'a>(
         bufs
     };
 
-    Ok((msg_mut, name, bufs))
+    Ok((msg_mut, name, control, bufs))
 }

--- a/src/libos/src/net/syscalls.rs
+++ b/src/libos/src/net/syscalls.rs
@@ -220,12 +220,7 @@ pub async fn do_sendto(
     if addr.is_null() ^ (addr_len == 0) {
         return_errno!(EINVAL, "addr and addr_len should be both null and 0 or not");
     }
-    let addr = if socket_file.is_stream() {
-        if !addr.is_null() {
-            return_errno!(EISCONN, "addr and addr_len should be null and 0");
-        }
-        None
-    } else {
+    let addr = {
         if addr.is_null() {
             None
         } else {

--- a/src/libos/src/net/syscalls.rs
+++ b/src/libos/src/net/syscalls.rs
@@ -311,6 +311,9 @@ pub async fn do_recvmsg(fd: c_int, msg_mut_ptr: *mut libc::msghdr, flags: c_int)
         }
     }
 
+    // Clear msghdr flags to 0 after recvmsg
+    msg.msg_flags = 0;
+
     Ok(bytes_recv as isize)
 }
 

--- a/src/libos/src/net/unix/mod.rs
+++ b/src/libos/src/net/unix/mod.rs
@@ -102,11 +102,11 @@ impl UnixStream {
             let untrusted_sock = UntrustedUnixStream::new(nonblocking)?;
 
             // Bind the Host FS address
-            // let untrusted_socks = UNTRUSTED_SOCKS.read().unwrap();
             let host_addr = Self::get_host_socket_file_path(addr, host_path, is_socket_file);
-            info!(
-                "bind crossworld sock: libos path: {:?}, host path: {:?}",
-                addr, host_addr
+            trace!(
+                "bind cross world sock: libos path: {:?}, host path: {:?}",
+                addr,
+                host_addr
             );
             addr.bind_untrusted_addr(&host_addr)?; // bind two address
             untrusted_sock.bind(&host_addr)?;
@@ -136,9 +136,10 @@ impl UnixStream {
             let untrusted_sock = UntrustedUnixStream::new(nonblocking)?;
 
             let host_addr = Self::get_host_socket_file_path(addr, host_path, is_socket_file);
-            info!(
-                "connect crossworld sock: libos path: {:?}, host path: {:?}",
-                addr, host_addr
+            trace!(
+                "connect cross world sock: libos path: {:?}, host path: {:?}",
+                addr,
+                host_addr
             );
             untrusted_sock.connect(&host_addr).await?;
 
@@ -179,7 +180,11 @@ impl UnixStream {
         }
     }
 
-    pub async fn recvmsg(&self, buf: &mut [&mut [u8]], flags: RecvFlags) -> Result<usize> {
+    pub async fn recvmsg(
+        &self,
+        buf: &mut [&mut [u8]],
+        flags: RecvFlags,
+    ) -> Result<(usize, Option<UnixAddr>)> {
         apply_fn_on_any_stream!(self.inner(), |stream| { stream.recvmsg(buf, flags).await })
     }
 

--- a/src/libos/src/net/unix/mod.rs
+++ b/src/libos/src/net/unix/mod.rs
@@ -184,8 +184,11 @@ impl UnixStream {
         &self,
         buf: &mut [&mut [u8]],
         flags: RecvFlags,
+        control: Option<&mut [u8]>,
     ) -> Result<(usize, Option<UnixAddr>)> {
-        apply_fn_on_any_stream!(self.inner(), |stream| { stream.recvmsg(buf, flags).await })
+        apply_fn_on_any_stream!(self.inner(), |stream| {
+            stream.recvmsg(buf, flags, None).await
+        })
     }
 
     pub async fn sendmsg(&self, bufs: &[&[u8]], flags: SendFlags) -> Result<usize> {

--- a/src/libos/src/net/unix/mod.rs
+++ b/src/libos/src/net/unix/mod.rs
@@ -206,8 +206,8 @@ impl UnixStream {
         }
     }
 
-    pub fn shutdown(&self, how: Shutdown) -> Result<()> {
-        apply_fn_on_any_stream!(self.inner(), |stream| { stream.shutdown(how) })
+    pub async fn shutdown(&self, how: Shutdown) -> Result<()> {
+        apply_fn_on_any_stream!(self.inner(), |stream| { stream.shutdown(how).await })
     }
 }
 

--- a/src/libos/src/net/unix/trusted/stream/address_space.rs
+++ b/src/libos/src/net/unix/trusted/stream/address_space.rs
@@ -61,12 +61,8 @@ impl AddressSpace {
         let mut space = self.get_space(addr);
 
         if let Some(option) = space.get(&key) {
-            if option.is_none() {
-                space.insert(key, Some(Arc::new(Listener::new(capacity, nonblocking)?)));
-                Ok(())
-            } else {
-                return_errno!(EINVAL, "the socket is already listened");
-            }
+            space.insert(key, Some(Arc::new(Listener::new(capacity, nonblocking)?)));
+            Ok(())
         } else {
             return_errno!(EINVAL, "the socket is not bound");
         }

--- a/src/libos/src/net/unix/trusted/stream/sock_end.rs
+++ b/src/libos/src/net/unix/trusted/stream/sock_end.rs
@@ -65,6 +65,14 @@ impl Inner {
         self.peer.upgrade().map(|end| end.addr().clone()).flatten()
     }
 
+    pub fn writer(&self) -> &Producer<u8> {
+        &self.writer
+    }
+
+    pub fn reader(&self) -> &Consumer<u8> {
+        &self.reader
+    }
+
     pub fn set_nonblocking(&self, nonblocking: bool) {
         let status_flag = {
             match nonblocking {

--- a/src/libos/src/net/unix/trusted/stream/stream.rs
+++ b/src/libos/src/net/unix/trusted/stream/stream.rs
@@ -36,7 +36,7 @@ impl Stream {
     }
 
     pub async fn readv(&self, bufs: &mut [&mut [u8]]) -> Result<usize> {
-        self.recvmsg(bufs, RecvFlags::empty())
+        self.recvmsg(bufs, RecvFlags::empty(), None)
             .await
             .map(|ret| ret.0)
     }
@@ -49,6 +49,7 @@ impl Stream {
         &self,
         bufs: &mut [&mut [u8]],
         flags: RecvFlags,
+        control: Option<&mut [u8]>,
     ) -> Result<(usize, Option<UnixAddr>)> {
         let addr = {
             let trusted_addr = self.peer_addr().ok();

--- a/src/libos/src/net/unix/trusted/stream/stream.rs
+++ b/src/libos/src/net/unix/trusted/stream/stream.rs
@@ -36,17 +36,33 @@ impl Stream {
     }
 
     pub async fn readv(&self, bufs: &mut [&mut [u8]]) -> Result<usize> {
-        self.recvmsg(bufs, RecvFlags::empty()).await
+        self.recvmsg(bufs, RecvFlags::empty())
+            .await
+            .map(|ret| ret.0)
     }
 
     /// Linux behavior:
     /// Unlike datagram socket, `recvfrom` / `recvmsg` of stream socket will
-    /// ignore the address even if user specified it. For stream socket, If user
-    /// want to get source address , user should use `getpeername` syscall.
+    /// ignore the address even if user specified it.
     /// TODO: handle flags
-    pub async fn recvmsg(&self, bufs: &mut [&mut [u8]], flags: RecvFlags) -> Result<usize> {
-        let addr = self.peer_addr().ok();
-        debug!("recvfrom {:?}", addr);
+    pub async fn recvmsg(
+        &self,
+        bufs: &mut [&mut [u8]],
+        flags: RecvFlags,
+    ) -> Result<(usize, Option<UnixAddr>)> {
+        let addr = {
+            let trusted_addr = self.peer_addr().ok();
+            debug!("recvfrom {:?}", trusted_addr);
+            if let Some(addr) = trusted_addr {
+                match addr.inner() {
+                    UnixAddr::Pathname(path) => Some(UnixAddr::Pathname(path.clone())),
+                    UnixAddr::Abstract(name) => Some(UnixAddr::Abstract(name.clone())),
+                    UnixAddr::Unnamed => None,
+                }
+            } else {
+                None
+            }
+        };
 
         let connected_stream = {
             match &*self.inner() {
@@ -58,7 +74,7 @@ impl Stream {
         };
         let data_len = connected_stream.readv(bufs).await?;
 
-        Ok(data_len)
+        Ok((data_len, addr))
     }
 
     pub async fn write(&self, buf: &[u8]) -> Result<usize> {
@@ -72,7 +88,7 @@ impl Stream {
     // TODO: handle flags
     pub async fn sendmsg(&self, bufs: &[&[u8]], flags: SendFlags) -> Result<usize> {
         let addr = self.peer_addr().ok();
-        debug!("recvfrom {:?}", addr);
+        debug!("sendmsg to {:?}", addr);
 
         let connected_stream = {
             match &*self.inner() {
@@ -252,9 +268,15 @@ impl Stream {
                     return_errno!(EINVAL, "the socket is not bound");
                 }
             }
+            Status::Listening(addr) => {
+                if let Some(listener) = ADDRESS_SPACE.get_listener_ref(addr) {
+                    let nonblocking = listener.nonblocking();
+                    ADDRESS_SPACE.add_listener(addr, capacity, nonblocking)?;
+                } else {
+                    return_errno!(EINVAL, "something wrong with listen");
+                }
+            }
             Status::Connected(_) => return_errno!(EINVAL, "the socket is already connected"),
-            // Modify the capacity of the channel holding incoming sockets
-            Status::Listening(addr) => return_errno!(EINVAL, "already listening"),
         }
 
         Ok(())
@@ -355,11 +377,9 @@ impl Debug for Stream {
 
 impl Drop for Stream {
     fn drop(&mut self) {
-        info!("Drop trusted stream in idle state");
         match &*self.inner() {
             Status::Idle(info) => {
                 if let Some(addr) = info.addr() {
-                    info!("Drop trusted stream in idle state");
                     ADDRESS_SPACE.remove_addr(&addr);
                 }
             }

--- a/src/libos/src/net/unix/trusted/stream/stream.rs
+++ b/src/libos/src/net/unix/trusted/stream/stream.rs
@@ -338,7 +338,7 @@ impl Stream {
         }
     }
 
-    pub fn shutdown(&self, how: Shutdown) -> Result<()> {
+    pub async fn shutdown(&self, how: Shutdown) -> Result<()> {
         if let Status::Connected(ref end) = &*self.inner() {
             end.shutdown(how)
         } else {

--- a/src/libos/src/net/unix/trusted/stream/stream.rs
+++ b/src/libos/src/net/unix/trusted/stream/stream.rs
@@ -4,11 +4,12 @@ use super::*;
 use async_io::event::{Events, Observer, Poller};
 use async_io::file::StatusFlags;
 use async_io::ioctl::IoctlCmd;
-use async_io::socket::Shutdown;
+use async_io::socket::{SetRecvTimeoutCmd, SetSendTimeoutCmd, Shutdown, Timeout};
 use async_io::util::channel::Channel;
 use std::fmt;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use std::time::Duration;
 
 /// Unix socket based on trusted channel. It has three statuses: unconnected, listening and connected.  When a
 /// socket is created, it is in unconnected status.  It will transfer to listening after listen is
@@ -147,6 +148,22 @@ impl Stream {
             },
             cmd: SetNonBlocking => {
                 self.set_nonblocking(*cmd.input() != 0); // 0 means blocking
+            },
+            cmd: SetRecvTimeoutCmd => {
+                match &*self.inner() {
+                    Status::Connected(endpoint) => {
+                        endpoint.reader().set_receiver_timeout(*cmd.timeout());
+                    }
+                    _ => warn!("set recv timeout for other states not supported"),
+                }
+            },
+            cmd: SetSendTimeoutCmd => {
+                match &mut *self.inner() {
+                    Status::Connected(endpoint) => {
+                        endpoint.writer().set_sender_timeout(*cmd.timeout());
+                    }
+                    _ => warn!("set send timeout for other states not supported"),
+                }
             },
             cmd: SetSockOptRawCmd => {
                 // FIXME: Currently, it is harmless to ignore errors here.
@@ -312,7 +329,6 @@ impl Stream {
             Status::Idle(info) => info.nonblocking(),
             Status::Connected(endpoint) => endpoint.nonblocking(),
             Status::Listening(addr) => ADDRESS_SPACE.get_listener_ref(&addr).unwrap().nonblocking(),
-            // _ => unreachable!(),
         }
     }
 
@@ -324,7 +340,6 @@ impl Stream {
                 .get_listener_ref(&addr)
                 .unwrap()
                 .set_nonblocking(nonblocking),
-            // _ => unreachable!(),
         }
     }
 }

--- a/src/libos/src/net/unix/trusted/trusted_addr.rs
+++ b/src/libos/src/net/unix/trusted/trusted_addr.rs
@@ -67,12 +67,9 @@ impl TrustedAddr {
                 return_errno!(EPERM, "libos socket file cannot be created");
             }
 
-            info!("sock name = {:?}", sock_name);
             let socket_inode = dir_inode.create(&sock_name, FileType::Socket, 0o0777)?;
             let data = host_addr.get_path_name()?.as_bytes();
-            info!("data = {:?}", data);
             socket_inode.resize(data.len())?;
-            info!("here");
             socket_inode.write_at(0, data)?;
         }
         Ok(())

--- a/src/libos/src/net/unix/untrusted.rs
+++ b/src/libos/src/net/unix/untrusted.rs
@@ -25,5 +25,4 @@ pub fn untrusted_unix_socks_init() {
             untrusted_socks.insert(libos_addr, host_unix_addr);
         })
     }
-    info!("untrusted socks = {:?}", &*untrusted_socks);
 }

--- a/src/libos/src/util/mem_util.rs
+++ b/src/libos/src/util/mem_util.rs
@@ -27,6 +27,12 @@ pub mod from_user {
 
     /// Check the readonly array is within the readable memory of the user process
     pub fn check_array<T>(user_buf: *const T, count: usize) -> Result<()> {
+        // If user_buf pointer is null and count is zero, it is ok.
+        if user_buf.is_null() && count == 0 {
+            debug!("the user buf pointer is NULL and count is zero");
+            return Ok(());
+        }
+
         let checked_len = count
             .checked_mul(size_of::<T>())
             .ok_or_else(|| errno!(EINVAL, "the array is too long"))?;

--- a/test/include/test.h
+++ b/test/include/test.h
@@ -12,6 +12,9 @@
 #define MIN(a, b)               ((a) <= (b) ? (a) : (b))
 #define MAX(a, b)               ((a) >= (b) ? (a) : (b))
 #define ARRAY_SIZE(array)   (sizeof(array)/sizeof(array[0]))
+#define LONG_TEST_MSG "Occlum is a memory-safe, multi-process library OS (LibOS) for Intel SGX. \
+                    As a LibOS, it enables legacy applications to run on SGX with little or even \
+                    no modifications of source code, thus protecting the confidentiality and integrity of user workloads transparently."
 
 typedef int(*test_case_func_t)(void);
 

--- a/test/server/main.c
+++ b/test/server/main.c
@@ -724,7 +724,7 @@ void *client_routine(void *arg) {
 
     if (connRtn != 0) {
         printf("clientRoutine: error in connec");
-        return NULL;
+        return (void *) -1;
     }
 
     switch (port) {
@@ -739,6 +739,57 @@ void *client_routine(void *arg) {
             write(sockFd, msg[0], strlen(msg[0]));
             break;
         };
+        case 54323: { // for test_timeout
+            sleep(4); // wait for the server to write until blocking
+            printf("client sleep done\n");
+
+            // Test connect timeout
+            int timeout_caught = 0;
+            struct timeval timeout;
+            timeout.tv_sec = 1;
+            timeout.tv_usec = 0;
+            int ret;
+            int test_write_fd;
+            for (int i = 0; i < 10; i++) {
+                int test_fd = socket(AF_INET, SOCK_STREAM, 0);
+                if (test_fd < 0) {
+                    printf("connectToTcp: error in socket(), %s\n", strerror(errno));
+                    return (void *) -1;
+                }
+
+                ret = setsockopt(test_fd, SOL_SOCKET, SO_SNDTIMEO, &timeout, sizeof(timeout));
+                if (ret < 0) {
+                    printf("failed to set socket send timeout\n");
+                    return NULL;
+                }
+                ret = connect(test_fd, (struct sockaddr *)&sockAdr,
+                              sizeof(sockAdr));
+                if (ret == -1 &&
+                        errno == EINPROGRESS) { // The timeout errno is EINPROGRESS for connect(). Verified on Linux.
+                    printf("connect timeout caught successfully\n");
+                    timeout_caught ++;
+                    break;
+                }
+                test_write_fd = test_fd;
+            }
+            while (1) {
+                ret = write(test_write_fd, LONG_TEST_MSG, strlen(LONG_TEST_MSG));
+                if (ret < 0 ) {
+                    if (errno == EAGAIN) {
+                        printf("write timeout caught successfully\n");
+                        break;
+                    } else {
+                        printf("failed to write\n");
+                        return (void *) -1;
+                    }
+                }
+            }
+
+            if (timeout_caught == 0) {
+                printf("connect timeout failed\n");
+                return (void *) -1;
+            }
+        }
     }
 
     shutdown(sockFd, SHUT_RDWR);
@@ -890,6 +941,98 @@ int test_epoll_wait() {
     return 0;
 }
 
+int test_timeout() {
+    struct sockaddr_in serv_addr = {};
+    int port = 54323;
+    int ret;
+    pthread_t client_tid;
+    struct sockaddr_in saddr;
+    unsigned int saddr_ln = sizeof(saddr);
+    char read_buf[10];
+    void *client_ret = NULL;
+    struct timeval timeout;
+    timeout.tv_sec = 1;
+    timeout.tv_usec = 0;
+
+    int sockfd = socket(AF_INET, SOCK_STREAM, 0);
+    if (sockfd < 0) {
+        THROW_ERROR("server_routine, error creating socket");
+    }
+
+    serv_addr.sin_family = AF_INET;
+    serv_addr.sin_addr.s_addr = inet_addr("127.0.0.1");
+    serv_addr.sin_port = htons(port);
+
+    if (bind(sockfd, (struct sockaddr *)&serv_addr, sizeof(serv_addr)) < 0) {
+        THROW_ERROR("server_routine, error binding socket");
+    }
+
+    if (listen(sockfd, 2) != 0) {
+        THROW_ERROR("server_routine, error in listen");
+    }
+
+    // Set timeout for accept
+    ret = setsockopt(sockfd, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout));
+    if (ret < 0) {
+        THROW_ERROR("failed to set socket recv timeout");
+    }
+    // Test accept timeout
+    ret = accept(sockfd, (struct sockaddr *)&saddr, &saddr_ln);
+    if (ret == -1 && errno == EAGAIN) {
+        printf("accept timeout caught successfully\n");
+    } else {
+        THROW_ERROR("failed to catch accept timeout");
+    }
+
+    // Create client routine
+    if (pthread_create(&client_tid, NULL, client_routine, (void *)&port)) {
+        THROW_ERROR("Failure creating client thread");
+    }
+
+    int newsock = accept(sockfd, (struct sockaddr *)&saddr, &saddr_ln);
+    if (newsock == -1) {
+        THROW_ERROR("server_routine, error in accept");
+    }
+
+    // Set timeout for send and recv
+    ret = setsockopt(newsock, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout));
+    if (ret < 0) {
+        THROW_ERROR("failed to set socket recv timeout");
+    }
+    ret = setsockopt(newsock, SOL_SOCKET, SO_SNDTIMEO, &timeout, sizeof(timeout));
+    if (ret < 0) {
+        THROW_ERROR("failed to set socket send timeout");
+    }
+
+    // Test write timeout
+    while (1) {
+        ret = write(newsock, LONG_TEST_MSG, strlen(LONG_TEST_MSG));
+        if (ret < 0 ) {
+            if (errno == EAGAIN) {
+                printf("write timeout caught successfully\n");
+                break;
+            } else {
+                THROW_ERROR("failed to write");
+            }
+        }
+    }
+
+    // Test read timeout
+    ret = read(newsock, read_buf, sizeof(read_buf));
+    if (ret < 0 && errno == EAGAIN) {
+        printf("read timeout caught successfully\n");
+    } else {
+        THROW_ERROR("read should have timed out");
+    }
+
+    // Check client thread status
+    pthread_join(client_tid, &client_ret);
+    if (client_ret != NULL) {
+        THROW_ERROR("client thread failed");
+    }
+    return 0;
+}
+
 static test_case_t test_cases[] = {
     TEST_CASE(test_MSG_WAITALL),
     TEST_CASE(test_read_write),
@@ -908,6 +1051,7 @@ static test_case_t test_cases[] = {
     TEST_CASE(test_getname_without_bind),
     TEST_CASE(test_shutdown),
     TEST_CASE(test_epoll_wait),
+    TEST_CASE(test_timeout),
 };
 
 int main(int argc, const char *argv[]) {

--- a/test/unix_socket/Makefile
+++ b/test/unix_socket/Makefile
@@ -1,5 +1,5 @@
 include ../test_common.mk
 
 EXTRA_C_FLAGS := -Wno-incompatible-pointer-types-discards-qualifiers
-EXTRA_LINK_FLAGS :=
+EXTRA_LINK_FLAGS := -lpthread
 BIN_ARGS :=

--- a/test/unix_socket/main.c
+++ b/test/unix_socket/main.c
@@ -375,6 +375,53 @@ int test_ioctl_fionread() {
     return 0;
 }
 
+int test_send_recv_timeout() {
+    int socks[2];
+    char read_buf[10];
+    int ret = 0;
+    int test_sock_end;
+    struct timeval timeout;
+    timeout.tv_sec = 1;
+    timeout.tv_usec = 0;
+
+    if (socketpair_default(socks) < 0) {
+        THROW_ERROR("failed to create a unix socket pair");
+    }
+    test_sock_end = socks[0];
+
+    ret = setsockopt(test_sock_end, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout));
+    if (ret < 0) {
+        THROW_ERROR("failed to set socket recv timeout");
+    }
+    ret = setsockopt(test_sock_end, SOL_SOCKET, SO_SNDTIMEO, &timeout, sizeof(timeout));
+    if (ret < 0) {
+        THROW_ERROR("failed to set socket send timeout");
+    }
+
+    // send continuously until kernel buffer is full and send is blocked
+    while (1) {
+        ret = send(test_sock_end, LONG_TEST_MSG, strlen(LONG_TEST_MSG), 0);
+        if (ret < 0 ) {
+            if (errno == EAGAIN) {
+                printf("send timeout caught successfully\n");
+                break;
+            } else {
+                THROW_ERROR("failed to send");
+            }
+        }
+    }
+
+    // blocking recv
+    ret = recv(test_sock_end, read_buf, sizeof(read_buf), 0);
+    if (ret < 0 && errno == EAGAIN) {
+        printf("read timeout caught successfully\n");
+    } else {
+        THROW_ERROR("read should have timed out");
+    }
+
+    return 0;
+}
+
 static test_case_t test_cases[] = {
     TEST_CASE(test_unix_socket_inter_process),
     TEST_CASE(test_socketpair_inter_process),
@@ -383,6 +430,7 @@ static test_case_t test_cases[] = {
     TEST_CASE(test_getname),
     TEST_CASE(test_ioctl_fionread),
     TEST_CASE(test_unix_socket_rename),
+    TEST_CASE(test_send_recv_timeout),
 };
 
 int main(int argc, const char *argv[]) {


### PR DESCRIPTION
The number of unpassed udp-related gvisor tests has been reduced from 643 to 235. Besides, the basic function of udp socket has been implemented, and the udp iperf2 can run stably. Still work in progress!

TODO:
- [x] Support timeout
- [x] Support ioctl-related operations
- [x] Support more flags