### PR TITLE
[benchmark ci] Add fio to benchmark ci

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -105,3 +105,53 @@ jobs:
     - name: Clean the environment
       if: ${{ always() }}
       run: docker stop ${{ env.CONTAINER_NAME }}
+
+  FIO_Test:
+    timeout-minutes: 60
+    runs-on: ${{ matrix.self_runner }}
+    strategy:
+      matrix:
+        self_runner: [[self-hosted, SGX2-HW, benchmark]]
+
+    steps:
+    - name: Clean before running
+      run: |
+        sudo chown -R ${{ secrets.CI_ADMIN }} "${{ github.workspace }}"
+
+    - name: Checkout code
+      uses: actions/checkout@v2
+      with:
+        submodules: true
+
+    - uses: ./.github/workflows/composite_action/hw
+      with:
+        container-name: ${{ github.job }}
+        build-envs: 'OCCLUM_RELEASE_BUILD=1'
+
+    - name: Run fio download and build
+      run: docker exec ${{ env.CONTAINER_NAME }} bash -c "cd /root/occlum/demos/benchmarks/fio && ./fio_microbench.sh"
+
+    - name: Copy result
+      run: docker cp ${{ env.CONTAINER_NAME }}:/root/occlum/demos/benchmarks/fio/result.json .
+
+    # Run `github-action-benchmark` action
+    - name: Store benchmark result
+      uses: benchmark-action/github-action-benchmark@v1
+      with:
+        name: FIO Benchmark
+        # What benchmark tool the output.txt came from
+        tool: 'customBiggerIsBetter'
+        # Where the output from the benchmark tool is stored
+        output-file-path: result.json
+        # Path to directory which contains benchmark files on GitHub pages branch
+        benchmark-data-dir-path: 'dev/benchmarks'
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        auto-push: true
+        # Show alert with commit comment on detecting possible performance regression
+        alert-threshold: '200%'
+        comment-on-alert: true
+        # Workflow will fail when an alert happens
+        fail-on-alert: true
+    - name: Clean the environment
+      if: ${{ always() }}
+      run: docker stop ${{ env.CONTAINER_NAME }}

--- a/demos/benchmarks/fio/configs/fio-microbench.fio
+++ b/demos/benchmarks/fio/configs/fio-microbench.fio
@@ -1,0 +1,43 @@
+# fio-microbench.fio
+
+[global]
+# Change 'filename' to target path
+filename=/root/fio-microbench
+ioengine=sync
+size=10G
+loops=3
+thread=1
+numjobs=1
+direct=1
+fsync_on_close=1
+time_based=0
+
+
+# Write
+
+[seq-write-256k]
+stonewall
+group_reporting
+rw=write
+bs=256k
+
+[rand-write-32k]
+stonewall
+group_reporting
+rw=randwrite
+bs=32k
+
+
+# Read
+
+[seq-read-256k]
+stonewall
+group_reporting
+rw=read
+bs=256k
+
+[rand-read-32k]
+stonewall
+group_reporting
+rw=randread
+bs=32k

--- a/demos/benchmarks/fio/download_and_build_fio.sh
+++ b/demos/benchmarks/fio/download_and_build_fio.sh
@@ -16,6 +16,6 @@ fi
 
 # Build FIO
 ./configure --disable-shm --cc=occlum-gcc
-make
+make -j$(nproc)
 
 echo "Build FIO success!"

--- a/demos/benchmarks/fio/fio_microbench.sh
+++ b/demos/benchmarks/fio/fio_microbench.sh
@@ -1,0 +1,49 @@
+#! /bin/bash
+set -e
+
+CUR_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+MICRO_CONFIG="fio-microbench.fio"
+
+function fio_prepare()
+{
+    ./download_and_build_fio.sh
+}
+
+function fio_run()
+{
+    echo ""
+    echo "*** Doing fio microbenchmarks ***"
+
+    ./run_fio_on_occlum.sh ${MICRO_CONFIG} | tee output.txt
+}
+
+function fio_result()
+{
+    output="${CUR_DIR}/output.txt"
+
+    # Parse write-test results
+    write_output=$(grep "WRITE:" ${output} | awk '{print $2}')
+    write_seq=$(echo ${write_output} | awk '{print $1}')
+    WRITE_SEQ=${write_seq:3:-5}
+    write_rand=$(echo ${write_output} | awk '{print $2}')
+    WRITE_RAND=${write_rand:3:-5}
+
+    # Parse read-test results
+    read_output=$(grep "READ:" ${output} | awk '{print $2}')
+    read_seq=$(echo ${read_output} | awk '{print $1}')
+    READ_SEQ=${read_seq:3:-5}
+    read_rand=$(echo ${read_output} | awk '{print $2}')
+    READ_RAND=${read_rand:3:-5}
+
+    jq --argjson seqwrite $WRITE_SEQ --argjson randwrite $WRITE_RAND --argjson seqread $READ_SEQ --argjson randread $READ_RAND \
+        '(.[] | select(.extra == "seqwrite") | .value) |= $seqwrite |
+        (.[] | select(.extra == "randwrite") | .value) |= $randwrite |
+        (.[] | select(.extra == "seqread") | .value) |= $seqread |
+        (.[] | select(.extra == "randread") | .value) |= $randread'  \
+        result_template.json  > result.json
+
+}
+
+fio_prepare
+fio_run
+fio_result

--- a/demos/benchmarks/fio/result_template.json
+++ b/demos/benchmarks/fio/result_template.json
@@ -1,0 +1,26 @@
+[
+    {
+        "name": "Sequential Write Throughput",
+        "unit": "MiB/s",
+        "value": 0,
+        "extra": "seqwrite"
+    },
+    {
+        "name": "Random Write Throughput",
+        "unit": "MiB/s",
+        "value": 0,
+        "extra": "randwrite"
+    },
+    {
+        "name": "Sequential Read Throughput",
+        "unit": "MiB/s",
+        "value": 0,
+        "extra": "seqread"
+    },
+    {
+        "name": "Random Read Throughput",
+        "unit": "MiB/s",
+        "value": 0,
+        "extra": "randread"
+    }
+]

--- a/demos/benchmarks/fio/run_fio_on_occlum.sh
+++ b/demos/benchmarks/fio/run_fio_on_occlum.sh
@@ -25,9 +25,7 @@ fi
 # 1. Init Occlum instance
 rm -rf occlum_instance && occlum new occlum_instance
 cd occlum_instance
-TCS_NUM=$(($(nproc) * 2))
-new_json="$(jq --argjson THREAD_NUM ${TCS_NUM} '.resource_limits.max_num_of_threads = $THREAD_NUM |
-                .resource_limits.user_space_size = "320MB"' Occlum.json)" && \
+new_json="$(jq '.resource_limits.user_space_size = "320MB"' Occlum.json)" && \
 echo "${new_json}" > Occlum.json
 
 # 2. Copy files into Occlum instance and build


### PR DESCRIPTION
This PR add FIO test to benchmark ci.
The workflow `FIO_Test` runs a microbenchmark on schedule.

Testing here:
- GitHub action: [here](https://github.com/lucassong-mh/ngo/actions/runs/3366568401/jobs/5583194405)
- Charts on GitHub Pages: [here](https://lucassong-mh.github.io/ngo/dev/benchmarks/)