### PR TITLE
Make page cache size configurable in Occlum.yaml

### DIFF
--- a/etc/template/Occlum.yaml
+++ b/etc/template/Occlum.yaml
@@ -117,8 +117,12 @@ mount:
   #   type: async_sfs
   #   source: ./run/async_sfs_image
   #   options:
+  #     # Total size that Async-SFS can manage. Must be specified.
   #     total_size: 4GB
-
+  #     # Page cache size that Async-SFS can use. Must be specified.
+  #     # When the `page_cache_size` is given, the `kernel_space_heap_size` must be increased equally.
+  #     page_cache_size: 256MB
+#
 # Untrusted Unix domain socket
 # Besides the common Unix domain socket support that both ends are created in the same
 # Occlum instance, the Untrusted Unix domain socket can support cross-world connection by

--- a/src/libos/Cargo.toml
+++ b/src/libos/Cargo.toml
@@ -41,7 +41,7 @@ io-uring-callback = { path = "crates/io-uring-callback", features = ["sgx"] }
 host-socket  = { path = "crates/host-socket", default-features = false, features = ["sgx"] }
 sgx-disk  = { path = "crates/sgx-disk", default-features = false, features = ["sgx"] }
 block-device  = { path = "crates/block-device" }
-page-cache = { path = "crates/page-cache", default-features = false, feature = ["sgx"] }
+page-cache = { path = "crates/page-cache", default-features = false, features = ["sgx"] }
 scroll = { version = "0.11.0", default-features = false }
 futures = { version = "0.3", default-features = false, features = ["alloc", "async-await"] }
 itertools = { version = "0.10.0", default-features = false, features = ["use_alloc"]  }

--- a/src/libos/src/config.rs
+++ b/src/libos/src/config.rs
@@ -194,6 +194,7 @@ pub struct ConfigMountOptions {
     pub layers: Option<Vec<ConfigMount>>,
     pub temporary: bool,
     pub total_size: Option<usize>,
+    pub page_cache_size: Option<usize>,
     pub index: u32,
     pub autokey_policy: Option<u32>,
 }
@@ -348,6 +349,11 @@ impl ConfigMountOptions {
         } else {
             None
         };
+        let page_cache_size = if input.page_cache_size.is_some() {
+            Some(parse_memory_size(input.page_cache_size.as_ref().unwrap())?)
+        } else {
+            None
+        };
         let layers = if let Some(layers) = &input.layers {
             let layers = layers
                 .iter()
@@ -362,6 +368,7 @@ impl ConfigMountOptions {
             layers,
             temporary: input.temporary,
             total_size,
+            page_cache_size,
             index: input.index,
             autokey_policy: input.autokey_policy,
         })
@@ -504,6 +511,8 @@ struct InputConfigMountOptions {
     pub temporary: bool,
     #[serde(default)]
     pub total_size: Option<String>,
+    #[serde(default)]
+    pub page_cache_size: Option<String>,
     #[serde(default)]
     pub index: u32,
     #[serde(default)]

--- a/src/libos/src/fs/rootfs.rs
+++ b/src/libos/src/fs/rootfs.rs
@@ -293,10 +293,12 @@ async fn open_or_create_async_sfs_according_to(
     }
     let source_path = mc.source.as_ref().unwrap();
 
+    if mc.options.page_cache_size.is_none() {
+        return_errno!(EINVAL, "Page cache size is expected for Async-SFS");
+    }
+    let page_cache_size = mc.options.page_cache_size.unwrap();
     // AsyncFsPageAlloc is a fixed-size allocator for page cache.
-    // TODO: Make the page cache size configurable
-    const MB: usize = 1024 * 1024;
-    impl_fixed_size_page_alloc! { AsyncFsPageAlloc, 256 * MB };
+    impl_fixed_size_page_alloc! { AsyncFsPageAlloc, page_cache_size };
 
     let async_sfs = if source_path.exists() {
         let cache_disk = {

--- a/test/Occlum.yaml
+++ b/test/Occlum.yaml
@@ -114,4 +114,4 @@ mount:
     source: ./run/async_sfs_image
     options:
       total_size: 4GB
- 
+      page_cache_size: 256MB

--- a/tools/gen_internal_conf/src/main.rs
+++ b/tools/gen_internal_conf/src/main.rs
@@ -487,6 +487,8 @@ struct OcclumMountOptions {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub total_size: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub page_cache_size: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     autokey_policy: Option<u32>,
 }
 


### PR DESCRIPTION
Now user can configure `page_cache_size` in Occlum.yaml under `mount.options`