### PR TITLE
Make occlum-go support gcc/glibc option

### DIFF
--- a/tools/installer/deb/toolchains/golang/rules
+++ b/tools/installer/deb/toolchains/golang/rules
@@ -36,7 +36,7 @@ override_dh_install:
 	rm -rf $(install_dir)/.git*
 	cat > $(install_dir)/bin/occlum-go <<EOF
 		#!/bin/bash
-		OCCLUM_GCC="\$$(which occlum-gcc)"
+		OCCLUM_GCC="\$${CC:-\$$(which occlum-gcc)}"
 		OCCLUM_GOFLAGS="-buildmode=pie \$$GOFLAGS"
 		CC=\$$OCCLUM_GCC GOFLAGS=\$$OCCLUM_GOFLAGS /opt/occlum/toolchains/golang/bin/go "\$$@"
 	EOF

--- a/tools/installer/rpm/toolchains/golang/occlum-toolchains-golang.spec
+++ b/tools/installer/rpm/toolchains/golang/occlum-toolchains-golang.spec
@@ -49,7 +49,7 @@ mv go-go%{GO_VERSION} %{buildroot}%{INSTALL_DIR}/golang
 rm -rf %{buildroot}%{INSTALL_DIR}/golang/.git*
 cat > %{buildroot}%{INSTALL_DIR}/golang/bin/occlum-go <<EOF
 #!/bin/bash
-OCCLUM_GCC="\$(which occlum-gcc)"
+OCCLUM_GCC="\${CC:-\$(which occlum-gcc)}"
 OCCLUM_GOFLAGS="-buildmode=pie \$GOFLAGS"
 CC=\$OCCLUM_GCC GOFLAGS=\$OCCLUM_GOFLAGS %{INSTALL_DIR}/golang/bin/go "\$@"
 EOF

--- a/tools/toolchains/golang/build.sh
+++ b/tools/toolchains/golang/build.sh
@@ -28,7 +28,7 @@ mv ${BUILD_DIR} ${INSTALL_DIR}
 # Generate the wrappers for Go
 cat > ${INSTALL_DIR}/bin/occlum-go <<EOF
 #!/bin/bash
-OCCLUM_GCC="\$(which occlum-gcc)"
+OCCLUM_GCC="\${CC:-\$(which occlum-gcc)}"
 OCCLUM_GOFLAGS="-buildmode=pie \$GOFLAGS"
 CC=\$OCCLUM_GCC GOFLAGS=\$OCCLUM_GOFLAGS ${INSTALL_DIR}/bin/go "\$@"
 EOF


### PR DESCRIPTION
In default, occlum-go uses musl-gcc. Users can configure occlum-go to use gcc like below.
" CC=gcc occlum-go build "